### PR TITLE
feat(plugin): openapi plugin now groups by service

### DIFF
--- a/.changeset/cold-turtles-flash.md
+++ b/.changeset/cold-turtles-flash.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-openapi": major
+---
+
+feat(plugin): openapi plugin now groups by service

--- a/packages/generator-federation/src/test/plugin.test.ts
+++ b/packages/generator-federation/src/test/plugin.test.ts
@@ -41,7 +41,7 @@ describe('generator-federation', () => {
       const services = await fs.readdir(path.join(catalogDir, 'services'));
       expect(services).toHaveLength(3);
     },
-    { timeout: 10000 }
+    { timeout: 20000 }
   );
 
   it(
@@ -60,7 +60,7 @@ describe('generator-federation', () => {
       const services = await fs.readdir(path.join(catalogDir, 'services'));
       expect(services).toHaveLength(4);
     },
-    { timeout: 10000 }
+    { timeout: 20000 }
   );
 
   it('if no copy configuration is provided then it clones target directory and copies all resources (e.g events, services, domains, teams, users) into the catalog', async () => {
@@ -98,7 +98,7 @@ describe('generator-federation', () => {
         const services = await fs.readdir(path.join(catalogDir, 'services'));
         expect(services).toHaveLength(2);
       },
-      { timeout: 10000 }
+      { timeout: 20000 }
     );
   });
 
@@ -130,7 +130,7 @@ describe('generator-federation', () => {
         const services = await fs.readdir(path.join(catalogDir, 'services'));
         expect(services).toHaveLength(3);
       },
-      { timeout: 10000 }
+      { timeout: 20000 }
     );
 
     it(
@@ -159,7 +159,7 @@ describe('generator-federation', () => {
         const services = await fs.readdir(path.join(catalogDir, 'services'));
         expect(services).toHaveLength(4);
       },
-      { timeout: 10000 }
+      { timeout: 20000 }
     );
   });
 
@@ -189,7 +189,7 @@ describe('generator-federation', () => {
           })
         ).rejects.toThrow(/Path already exists at/);
       },
-      { timeout: 10000 }
+      { timeout: 20000 }
     );
 
     it(
@@ -216,7 +216,7 @@ describe('generator-federation', () => {
           })
         ).rejects.toThrow(/Path already exists at/);
       },
-      { timeout: 10000 }
+      { timeout: 20000 }
     );
   });
 
@@ -251,7 +251,7 @@ describe('generator-federation', () => {
           })
         ).rejects.toThrow(/EventCatalog already has services with the id InventoryService/);
       },
-      { timeout: 10000 }
+      { timeout: 20000 }
     );
   });
 });

--- a/packages/generator-openapi/src/utils/catalog-shorthand.ts
+++ b/packages/generator-openapi/src/utils/catalog-shorthand.ts
@@ -30,6 +30,7 @@ export const getMessageTypeUtils = (projectDirectory: string, messageType: strin
       rmMessageById: rmEventById,
       writeMessage: writeEvent,
       addFileToMessage: addFileToEvent,
+      collection: 'events',
     },
     command: {
       versionMessage: versionCommand,
@@ -37,6 +38,7 @@ export const getMessageTypeUtils = (projectDirectory: string, messageType: strin
       rmMessageById: rmCommandById,
       writeMessage: writeCommand,
       addFileToMessage: addFileToCommand,
+      collection: 'commands',
     },
     query: {
       versionMessage: versionQuery,
@@ -44,6 +46,7 @@ export const getMessageTypeUtils = (projectDirectory: string, messageType: strin
       rmMessageById: rmQueryById,
       writeMessage: writeQuery,
       addFileToMessage: addFileToQuery,
+      collection: 'queries',
     },
   };
 


### PR DESCRIPTION
Changed the way the files are written to EventCatalog

The Plugin will now group queries, events and commands, inside the service folder (rather than the root project). If the domain is present the service will go inside the domain folder.

If users still want to write to root they can use `writeFilesToRoot` flag in the generator, this will do the old behaviour.

This is breaking change, so major version.