### PR TITLE
feat(plugin): asyncapi plugin now groups by service

### DIFF
--- a/packages/generator-asyncapi/src/types.ts
+++ b/packages/generator-asyncapi/src/types.ts
@@ -4,6 +4,7 @@ export interface MessageOperations {
   version: (id: string) => Promise<any>;
   get: (id: string, version: string) => Promise<any>;
   addSchema: (id: string, schema: any, version: any) => Promise<void>;
+  collection: string;
 }
 
 // Define valid event types


### PR DESCRIPTION
Changed the way the files are written to EventCatalog

The Plugin will now group queries, events and commands, inside the service folder (rather than the root project). If the domain is present the service will go inside the domain folder.

If users still want to write to root they can use writeFilesToRoot flag in the generator, this will do the old behaviour.

This is breaking change, so major version.