### PR TITLE
feat(plugin): if apigateway schemas are empty the render-schema-viewe…

### DIFF
--- a/.changeset/twelve-zoos-shop.md
+++ b/.changeset/twelve-zoos-shop.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-amazon-apigateway": patch
+---
+
+feat(plugin): if apigateway schemas are empty the render-schema-viewe…

--- a/packages/generator-amazon-apigateway/src/test/plugin.test.ts
+++ b/packages/generator-amazon-apigateway/src/test/plugin.test.ts
@@ -207,5 +207,29 @@ describe('Amazon API Gateway Plugin', () => {
 
       expect(parsedSpec.paths['/orders'].get['x-eventcatalog-message-name']).toEqual('MyCustomName');
     });
+
+    it('if the schema is empty, the x-eventcatalog-render-schema-viewer extension is set to false on that component', async () => {
+      await plugin(config, {
+        output: 'amazon-apigateway-specs',
+        apis: [
+          {
+            name: 'InfaApi',
+            region: 'us-east-1',
+            stageName: 'prod',
+            routes: {
+              'get /orders': {
+                type: 'command',
+                name: 'MyCustomName',
+              },
+            },
+          },
+        ],
+      });
+
+      const file = await fs.readFile(join(catalogDir, 'amazon-apigateway-specs', 'InfaApi.json'), 'utf-8');
+      const parsedSpec = JSON.parse(file);
+
+      expect(parsedSpec.components.schemas.Empty['x-eventcatalog-render-schema-viewer']).toEqual(false);
+    });
   });
 });

--- a/packages/generator-amazon-apigateway/src/utils/hydrate-openapi-file.ts
+++ b/packages/generator-amazon-apigateway/src/utils/hydrate-openapi-file.ts
@@ -49,8 +49,18 @@ export async function hydrate(openApiSpec: any, routeConfig: any, version?: numb
             operationObj['x-eventcatalog-message-name'] = config.name;
           }
         }
+
+        // Add render false for empty schemas
+        if (operationObj.requestBody?.content?.['application/json']?.schema?.title === 'Empty Schema') {
+          operationObj.requestBody.content['application/json'].schema['x-eventcatalog-render'] = false;
+        }
       }
     }
+  }
+
+  // Add render false for empty schemas in components
+  if (modifiedSpec.components?.schemas?.Empty?.title === 'Empty Schema') {
+    modifiedSpec.components.schemas.Empty['x-eventcatalog-render-schema-viewer'] = false;
   }
 
   return modifiedSpec;


### PR DESCRIPTION
When empty schemas are given from API Gateway, we append the `x-eventcatalog-render-schema-viewer` to them.

This is used in EventCatalog to hide the SchemaViewer, as there is not much value showing empty schema boxes.