### PR TITLE
feat(plugin): added ability to set owners on your openapi files

### DIFF
--- a/.changeset/empty-experts-study.md
+++ b/.changeset/empty-experts-study.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-openapi": patch
+---
+
+feat(plugin): added ability to set owners on your openapi files

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -125,6 +125,19 @@ describe('OpenAPI EventCatalog Plugin', () => {
           { id: 'simple-api-overview', version: '2.0.0' },
         ]);
       });
+
+      it('if the domain has owners, they are added to the domain', async () => {
+        const { getDomain } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [{ path: join(openAPIExamples, 'petstore.yml'), id: 'swagger-petstore' }],
+          domain: { id: 'orders', name: 'Orders', version: '1.0.0', owners: ['John Doe', 'Jane Doe'] },
+        });
+
+        const domain = await getDomain('orders', '1.0.0');
+
+        expect(domain.owners).toEqual(['John Doe', 'Jane Doe']);
+      });
     });
 
     describe('services', () => {
@@ -566,6 +579,18 @@ describe('OpenAPI EventCatalog Plugin', () => {
         ]);
       });
 
+      it('if the service has owners, they are added to the service', async () => {
+        const { getService } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [{ path: join(openAPIExamples, 'petstore.yml'), id: 'swagger-petstore', owners: ['John Doe', 'Jane Doe'] }],
+        });
+
+        const service = await getService('swagger-petstore', '1.0.0');
+
+        expect(service.owners).toEqual(['John Doe', 'Jane Doe']);
+      });
+
       describe('service options', () => {
         describe('config option: id', () => {
           it('if an `id` value is given in the service config options, then the generator uses that id and does not generate one from the title', async () => {
@@ -770,6 +795,24 @@ describe('OpenAPI EventCatalog Plugin', () => {
 
         expect(getCommandByProductId).toBeDefined();
         expect(getCommandMessage).toBeDefined();
+      });
+
+      it('when the service has owners, the messages are given the same owners', async () => {
+        const { getCommand } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [
+            { path: join(openAPIExamples, 'without-operationIds.yml'), id: 'product-api', owners: ['John Doe', 'Jane Doe'] },
+          ],
+        });
+
+        const getCommandByProductId = await getCommand('product-api_GET_{productId}');
+        const getCommandMessage = await getCommand('product-api_GET');
+
+        expect(getCommandByProductId).toBeDefined();
+        expect(getCommandMessage).toBeDefined();
+        expect(getCommandByProductId.owners).toEqual(['John Doe', 'Jane Doe']);
+        expect(getCommandMessage.owners).toEqual(['John Doe', 'Jane Doe']);
       });
 
       describe('schemas', () => {

--- a/packages/generator-openapi/src/types.ts
+++ b/packages/generator-openapi/src/types.ts
@@ -4,11 +4,14 @@ export type Domain = {
   id: string;
   name: string;
   version: string;
+  owners?: string[];
 };
 
 export type Service = {
   id: string;
   path: string;
+  owners?: string[];
+  setMessageOwnersToServiceOwners?: boolean;
 };
 
 export type Operation = {

--- a/packages/generator-openapi/src/utils/services.ts
+++ b/packages/generator-openapi/src/utils/services.ts
@@ -43,5 +43,7 @@ export const buildService = (serviceOptions: Service, document: OpenAPI.Document
     },
     markdown: defaultMarkdown(document, schemaPath),
     badges: documentTags.map((tag) => ({ content: tag.name, textColor: 'blue', backgroundColor: 'blue' })),
+    owners: serviceOptions.owners || [],
+    setMessageOwnersToServiceOwners: serviceOptions.setMessageOwnersToServiceOwners || true,
   };
 };


### PR DESCRIPTION
Added the ability to

- Add owners to your services or domains
- Adding owners to your services will set owners on all generated messages.