### PR TITLE
fix(plugin): openapi plugin now supports circular references in respo…

### DIFF
--- a/packages/generator-openapi/src/test/openapi-files/circlular-ref.yml
+++ b/packages/generator-openapi/src/test/openapi-files/circlular-ref.yml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: Employees API
+  version: 0.0.1
+paths:
+  /employees:
+    get:
+      summary: Returns a list of employees.
+      responses:
+        '200':
+          description: A JSON array of employees
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Employee'
+components:
+  schemas:
+    Employee:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        manager:
+          $ref: '#/components/schemas/Employee'

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -1015,5 +1015,32 @@ describe('OpenAPI EventCatalog Plugin', () => {
         })
       );
     });
+
+    it('when a spec file contains circular references, the plugin adds [Circular] to the schema', async () => {
+      await plugin(config, {
+        services: [{ path: join(openAPIExamples, 'circlular-ref.yml'), id: 'circular-ref-service' }],
+      });
+
+      const schema = await fs.readFile(
+        join(catalogDir, 'services', 'circular-ref-service', 'queries', 'employees-api_GET_employees', 'response-200.json'),
+        'utf8'
+      );
+      expect(schema).toEqual(`{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "name": {
+        "type": "string"
+      },
+      "manager": "[Circular]"
+    }
+  },
+  "isSchema": true
+}`);
+    });
   });
 });


### PR DESCRIPTION
Fixed an issue where circular references were not working as we were using JSON stringify. 

Now add [Circular] to the property value if this is the case.