### PR TITLE
fix(plugin): fixed issue with broken schema in EventCatalog if schema…

### DIFF
--- a/.changeset/hungry-rabbits-notice.md
+++ b/.changeset/hungry-rabbits-notice.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-asyncapi": patch
+---
+
+fix(plugin): fixed issue with broken schema in EventCatalog if schema…

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -355,7 +355,13 @@ export default async (config: any, options: Props) => {
           // Check if the message has a payload, if it does then document in EventCatalog
           if (messageHasSchema(message)) {
             // Get the schema from the original payload if it exists
-            const schema = message.payload()?.extensions()?.get('x-parser-original-payload')?.json() || message.payload()?.json();
+            let schema = message.payload()?.extensions()?.get('x-parser-original-payload')?.json() || message.payload()?.json();
+
+            // Sometimes the payload comes back with the schema nested in the payload
+            // if thats the case, we need to extract the schema from the payload (e.g async-file-with-schema-format.yml in tests folder)
+            if (schema?.schema) {
+              schema = schema.schema;
+            }
 
             await addSchemaToMessage(
               messageId,

--- a/packages/generator-asyncapi/src/test/asyncapi-files/async-file-with-schema-format.yml
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/async-file-with-schema-format.yml
@@ -1,0 +1,44 @@
+asyncapi: 3.0.0
+info:
+  title: my-service
+  version: 1.0.0
+  description: my service description
+defaultContentType: application/json
+operations:
+  projectDeleted:
+    action: receive
+    channel:
+      $ref: '#/channels/projectDeletedChannel'
+channels:
+  projectDeletedChannel:
+    address: /Message.ProjectDeleted
+    messages:
+      messageProjectDeleted:
+        $ref: '#/components/messages/messageProjectDeleted'
+components:
+  schemas:
+    ProjectHeader:
+      type: object
+      properties:
+        __TypeId__:
+          type: string
+          description: Spring Type Id Header
+    ProjectDeleted:
+      type: object
+      properties:
+        projectId:
+          type: string
+          description: The project id
+          example: 12345
+        projectName:
+          type: string
+          description: The project name
+          example: My Project
+  messages:
+    messageProjectDeleted:
+      headers:
+        $ref: '#/components/schemas/ProjectHeader'
+      payload:
+        schemaFormat: application/vnd.aai.asyncapi+json;version=3.0.0
+        schema:
+          $ref: '#/components/schemas/ProjectDeleted'

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -1415,5 +1415,38 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         })
       );
     });
+
+    it('when the message payload specifies a schema format, the schema written to EventCatalog just documents the schema values', async () => {
+      await plugin(config, {
+        services: [{ path: join(asyncAPIExamplesDir, 'async-file-with-schema-format.yml'), id: 'my-service' }],
+      });
+
+      // Get the schema
+      const schema = await fs.readFile(
+        join(catalogDir, 'services', 'my-service', 'events', 'messageProjectDeleted', 'schema.json'),
+        'utf-8'
+      );
+
+      const schemaParsed = JSON.parse(schema);
+
+      expect(schemaParsed).toEqual({
+        type: 'object',
+        properties: {
+          projectId: {
+            type: 'string',
+            description: 'The project id',
+            example: 12345,
+            'x-parser-schema-id': '<anonymous-schema-2>',
+          },
+          projectName: {
+            type: 'string',
+            description: 'The project name',
+            example: 'My Project',
+            'x-parser-schema-id': '<anonymous-schema-3>',
+          },
+        },
+        'x-parser-schema-id': 'ProjectDeleted',
+      });
+    });
   });
 });

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -1141,36 +1141,33 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         );
         const parsedSchema = JSON.parse(schema);
         expect(parsedSchema).toEqual({
-          schemaFormat: 'application/vnd.apache.avro;version=1.9.0',
-          schema: {
-            type: 'record',
-            name: 'UserCreated',
-            namespace: 'com.example.events',
-            fields: [
-              {
-                name: 'id',
-                type: 'string',
-                doc: 'User identifier',
-              },
-              {
-                name: 'email',
-                type: 'string',
-                doc: "User's email address",
-              },
-              {
-                name: 'createdAt',
-                type: 'long',
-                doc: 'Timestamp of user creation',
-                logicalType: 'timestamp-millis',
-              },
-              {
-                name: 'isActive',
-                type: 'boolean',
-                default: true,
-              },
-            ],
-            'x-parser-schema-id': '<anonymous-schema-1>',
-          },
+          type: 'record',
+          name: 'UserCreated',
+          namespace: 'com.example.events',
+          fields: [
+            {
+              name: 'id',
+              type: 'string',
+              doc: 'User identifier',
+            },
+            {
+              name: 'email',
+              type: 'string',
+              doc: "User's email address",
+            },
+            {
+              name: 'createdAt',
+              type: 'long',
+              doc: 'Timestamp of user creation',
+              logicalType: 'timestamp-millis',
+            },
+            {
+              name: 'isActive',
+              type: 'boolean',
+              default: true,
+            },
+          ],
+          'x-parser-schema-id': '<anonymous-schema-1>',
         });
 
         // Schema is now parsed, added as it was defined.


### PR DESCRIPTION
Fix for #104

• When a schemaformat is present on the payload of the schema, the schema value is incorrect for EventCatalog.
• For schemas for EventCatalog we stripe out the schemaFormat format so they can be rendered in EventCatalog.