### PR TITLE
feat(plugin): plugins now persist styles between generation

### DIFF
--- a/.changeset/lazy-otters-dress.md
+++ b/.changeset/lazy-otters-dress.md
@@ -1,0 +1,7 @@
+---
+"@eventcatalog/generator-asyncapi": patch
+"@eventcatalog/generator-eventbridge": patch
+"@eventcatalog/generator-openapi": patch
+---
+
+feat(plugin): plugins now persist styles between generation

--- a/packages/generator-asyncapi/package.json
+++ b/packages/generator-asyncapi/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@asyncapi/avro-schema-parser": "^3.0.24",
     "@asyncapi/parser": "^3.3.0",
-    "@eventcatalog/sdk": "^2.0.0",
+    "@eventcatalog/sdk": "^2.2.4",
     "chalk": "^4",
     "fs-extra": "^11.2.0",
     "glob": "^11.0.0",

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -182,7 +182,7 @@ export default async (config: any, options: Props) => {
     let serviceSpecifications = {};
     let serviceSpecificationsFiles = [];
     let serviceMarkdown = generateMarkdownForService(document);
-
+    let styles = null;
     // Have to ../ as the SDK will put the files into hard coded folders
     let servicePath = options.domain
       ? path.join('../', 'domains', options.domain.id, 'services', service.id)
@@ -393,7 +393,7 @@ export default async (config: any, options: Props) => {
       serviceMarkdown = latestServiceInCatalog.markdown;
       owners = latestServiceInCatalog.owners || owners;
       repository = latestServiceInCatalog.repository || null;
-
+      styles = latestServiceInCatalog.styles || null;
       // Found a service, and versions do not match, we need to version the one already there
       if (latestServiceInCatalog.version !== version) {
         await versionService(serviceId);
@@ -430,6 +430,7 @@ export default async (config: any, options: Props) => {
         },
         ...(owners && { owners }),
         ...(repository && { repository }),
+        ...(styles && { styles }),
       },
       {
         path: servicePath,

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -1445,5 +1445,58 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         'x-parser-schema-id': 'ProjectDeleted',
       });
     });
+
+    describe('persisted data', () => {
+      it('when the AsyncAPI service is already defined in EventCatalog and the versions match, the markdown is persisted and not overwritten', async () => {
+        // Create a service with the same name and version as the AsyncAPI file for testing
+        const { writeService, getService } = utils(catalogDir);
+
+        await writeService({
+          id: 'account-service',
+          version: '1.0.0',
+          name: 'Random Name',
+          markdown: 'Here is my original markdown, please do not override this!',
+          styles: {
+            icon: 'BellIcon',
+            node: {
+              color: 'red',
+              label: 'Custom Label',
+            },
+          },
+        });
+
+        await plugin(config, { services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service' }] });
+
+        const service = await getService('account-service', '1.0.0');
+        expect(service).toEqual(
+          expect.objectContaining({
+            id: 'account-service',
+            name: 'Account Service',
+            version: '1.0.0',
+            summary: 'This service is in charge of processing user signups',
+            markdown: 'Here is my original markdown, please do not override this!',
+            badges: [
+              {
+                content: 'Events',
+                textColor: 'blue',
+                backgroundColor: 'blue',
+              },
+              {
+                content: 'Authentication',
+                textColor: 'blue',
+                backgroundColor: 'blue',
+              },
+            ],
+            styles: {
+              icon: 'BellIcon',
+              node: {
+                color: 'red',
+                label: 'Custom Label',
+              },
+            },
+          })
+        );
+      });
+    });
   });
 });

--- a/packages/generator-eventbridge/package.json
+++ b/packages/generator-eventbridge/package.json
@@ -36,7 +36,7 @@
     "@aws-sdk/client-schemas": "^3.658.1",
     "@aws-sdk/util-arn-parser": "^3.568.0",
     "@changesets/cli": "^2.27.8",
-    "@eventcatalog/sdk": "^2.0.0",
+    "@eventcatalog/sdk": "^2.2.4",
     "chalk": "^4",
     "update-notifier": "^7.3.1"
   }

--- a/packages/generator-eventbridge/src/index.ts
+++ b/packages/generator-eventbridge/src/index.ts
@@ -239,6 +239,7 @@ export default async (config: EventCatalogConfig, options: GeneratorProps) => {
     // Check if service is already defined... if the versions do not match then create service.
     const latestServiceInCatalog = await getService(service.id, 'latest');
     let serviceMarkdown = generateMarkdownForService();
+    let styles = null;
     let serviceSpecifications = {};
     let serviceSpecificationsFiles = [];
     let sends = sendsEvents.map((event) => ({ id: event.detailType || event.schemaName, version: event.version || 'latest' }));
@@ -253,6 +254,7 @@ export default async (config: EventCatalogConfig, options: GeneratorProps) => {
     if (latestServiceInCatalog) {
       serviceMarkdown = latestServiceInCatalog.markdown;
       owners = latestServiceInCatalog.owners || [];
+      styles = latestServiceInCatalog.styles || null;
       // Found a service, and versions do not match, we need to version the one already there
       if (latestServiceInCatalog.version !== service.version) {
         await versionService(service.id);
@@ -284,6 +286,7 @@ export default async (config: EventCatalogConfig, options: GeneratorProps) => {
         receives,
         specifications: serviceSpecifications,
         owners: owners,
+        ...(styles && { styles }),
       },
       { path: servicePath, override: true }
     );

--- a/packages/generator-eventbridge/src/test/plugin.test.ts
+++ b/packages/generator-eventbridge/src/test/plugin.test.ts
@@ -1169,5 +1169,48 @@ describe('EventBridge EventCatalog Plugin', () => {
 
       expect(event).toBeDefined();
     });
+
+    describe('persisted data', () => {
+      it('when the service is already defined in EventCatalog and the versions match, the styles are persisted and not overwritten', async () => {
+        const { writeService, getService } = utils(catalogDir);
+
+        await writeService({
+          id: 'Orders Service',
+          version: '1.0.0',
+          name: 'Random Name',
+          markdown: 'old markdown',
+          styles: {
+            icon: 'BellIcon',
+            node: {
+              color: 'red',
+              label: 'Custom Label',
+            },
+          },
+        });
+        await plugin(config, {
+          region: 'us-east-1',
+          registryName: 'discovered-schemas',
+          services: [{ id: 'Orders Service', version: '1.0.0' }],
+        });
+
+        const service = await getService('Orders Service');
+
+        expect(service).toEqual(
+          expect.objectContaining({
+            id: 'Orders Service',
+            name: 'Orders Service',
+            version: '1.0.0',
+            markdown: 'old markdown',
+            styles: {
+              icon: 'BellIcon',
+              node: {
+                color: 'red',
+                label: 'Custom Label',
+              },
+            },
+          })
+        );
+      });
+    });
   });
 });

--- a/packages/generator-openapi/package.json
+++ b/packages/generator-openapi/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
     "@changesets/cli": "^2.27.7",
-    "@eventcatalog/sdk": "^2.0.1",
+    "@eventcatalog/sdk": "^2.2.4",
     "chalk": "^4",
     "js-yaml": "^4.1.0",
     "openapi-types": "^12.1.3",

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -126,6 +126,7 @@ export default async (_: any, options: Props) => {
 
     let owners = service.owners || [];
     let repository = null;
+    let styles = null;
 
     // Check if service is already defined... if the versions do not match then create service.
     const latestServiceInCatalog = await getService(service.id, 'latest');
@@ -137,6 +138,7 @@ export default async (_: any, options: Props) => {
       sends = latestServiceInCatalog.sends || ([] as any);
       owners = latestServiceInCatalog.owners || ([] as any);
       repository = latestServiceInCatalog.repository || null;
+      styles = latestServiceInCatalog.styles || null;
       // persist any specifications that are already in the catalog
       serviceSpecifications = {
         ...serviceSpecifications,
@@ -164,6 +166,7 @@ export default async (_: any, options: Props) => {
         receives,
         ...(owners ? { owners } : {}),
         ...(repository ? { repository } : {}),
+        ...(styles ? { styles } : {}),
       },
       { path: join(servicePath), override: true }
     );

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -1138,5 +1138,56 @@ describe('OpenAPI EventCatalog Plugin', () => {
   "isSchema": true
 }`);
     });
+
+    describe('persisted data', () => {
+      it('when the OpenAPI service is already defined in EventCatalog and the versions match, the styles are persisted and not overwritten', async () => {
+        // Create a service with the same name and version as the OpenAPI file for testing
+        const { writeService, getService } = utils(catalogDir);
+
+        await writeService(
+          {
+            id: 'swagger-petstore-2',
+            version: '1.0.0',
+            name: 'Random Name',
+            markdown: 'Here is my original markdown, please do not override this!',
+            styles: {
+              icon: 'BellIcon',
+              node: {
+                color: 'red',
+                label: 'Custom Label',
+              },
+            },
+          },
+          { path: 'Swagger Petstore' }
+        );
+
+        await plugin(config, { services: [{ path: join(openAPIExamples, 'petstore.yml'), id: 'swagger-petstore-2' }] });
+
+        const service = await getService('swagger-petstore-2', '1.0.0');
+        expect(service).toEqual(
+          expect.objectContaining({
+            id: 'swagger-petstore-2',
+            name: 'Swagger Petstore',
+            version: '1.0.0',
+            summary: 'This is a sample server Petstore server.',
+            markdown: 'Here is my original markdown, please do not override this!',
+            badges: [
+              {
+                content: 'Pets',
+                textColor: 'blue',
+                backgroundColor: 'blue',
+              },
+            ],
+            styles: {
+              icon: 'BellIcon',
+              node: {
+                color: 'red',
+                label: 'Custom Label',
+              },
+            },
+          })
+        );
+      });
+    });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
         specifier: ^3.3.0
         version: 3.4.0
       '@eventcatalog/sdk':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.2.4
+        version: 2.2.4
       chalk:
         specifier: ^4
         version: 4.1.2
@@ -198,8 +198,8 @@ importers:
         specifier: ^2.27.8
         version: 2.27.12
       '@eventcatalog/sdk':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.2.4
+        version: 2.2.4
       chalk:
         specifier: ^4
         version: 4.1.2
@@ -275,8 +275,8 @@ importers:
         specifier: ^2.27.7
         version: 2.27.12
       '@eventcatalog/sdk':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.2.4
+        version: 2.2.4
       chalk:
         specifier: ^4
         version: 4.1.2
@@ -874,8 +874,8 @@ packages:
   '@eventcatalog/sdk@2.0.0':
     resolution: { integrity: sha512-2qrYit3psOWWT29xDY+KuHOLkXw5fMpfU+/LgZSRZI6ZDB1pyxlqP/3ibJmL9RW7atgSzxHT7sIrHswjkbbuKg== }
 
-  '@eventcatalog/sdk@2.0.1':
-    resolution: { integrity: sha512-inNPpEtRRHmH29LVh1jLlZYRFxYNF8BgOmpp9kGULCty3ZMl9XkKcLKYgdYiRze0INvY/i0gVInosKfnGm2HGg== }
+  '@eventcatalog/sdk@2.2.4':
+    resolution: { integrity: sha512-+98Bi/+Zb75vsptQgIKuIZpVUMWMudo++1TKCRJI8z4UT3hyFRQ+GxqaLDYehBQ4Gu+Y8pp18m5uleg67Pz0ZQ== }
 
   '@huggingface/jinja@0.3.3':
     resolution: { integrity: sha512-vQQr2JyWvVFba3Lj9es4q9vCl1sAc74fdgnEMoX8qHrXtswap9ge9uO3ONDzQB0cQ0PUyaKY2N6HaVbTBvSXvw== }
@@ -4371,7 +4371,7 @@ snapshots:
       proper-lockfile: 4.1.2
       semver: 7.6.3
 
-  '@eventcatalog/sdk@2.0.1':
+  '@eventcatalog/sdk@2.2.4':
     dependencies:
       '@changesets/cli': 2.27.12
       fs-extra: 11.3.0
@@ -4379,6 +4379,7 @@ snapshots:
       gray-matter: 4.0.3
       proper-lockfile: 4.1.2
       semver: 7.6.3
+      slugify: 1.6.6
 
   '@huggingface/jinja@0.3.3': {}
 


### PR DESCRIPTION
Users can now use the new `styles` frontmatter to customize the node graph.

The plugins now persist any styles that have been created by the users between versions.