### PR TITLE
feat(plugin): openapi now supports deprecated fields

### DIFF
--- a/packages/generator-openapi/package.json
+++ b/packages/generator-openapi/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
     "@changesets/cli": "^2.27.7",
-    "@eventcatalog/sdk": "^2.2.4",
+    "@eventcatalog/sdk": "^2.2.6",
     "chalk": "^4",
     "js-yaml": "^4.1.0",
     "openapi-types": "^12.1.3",

--- a/packages/generator-openapi/src/test/openapi-files/petstore.yml
+++ b/packages/generator-openapi/src/test/openapi-files/petstore.yml
@@ -23,6 +23,8 @@ paths:
       operationId: listPets
       tags:
         - pets
+      x-eventcatalog-deprecated-date: 2025-04-09
+      x-eventcatalog-deprecated-message: This operation is deprecated because it is not used in the codebase
       x-eventcatalog-message-type: query # This is a query operation
       x-eventcatalog-message-name: List Pets # Name used in EventCatalog
       x-eventcatalog-message-id: list-pets # ID value used in EventCatalog
@@ -59,6 +61,7 @@ paths:
       operationId: createPets
       tags:
         - pets
+      deprecated: true
       x-eventcatalog-message-type: command # This is a command operation
       requestBody:
         content:

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -821,6 +821,28 @@ describe('OpenAPI EventCatalog Plugin', () => {
         expect(getCommandMessage.owners).toEqual(['John Doe', 'Jane Doe']);
       });
 
+      it('when the message has been marked as deprecated (with x-eventcatalog-deprecated-date and x-eventcatalog-deprecated-message), the message is marked as deprecated in EventCatalog', async () => {
+        const { getCommand } = utils(catalogDir);
+
+        await plugin(config, { services: [{ path: join(openAPIExamples, 'petstore.yml'), id: 'swagger-petstore' }] });
+
+        const command = await getCommand('list-pets');
+        expect(command.deprecated).toEqual({
+          date: '2025-04-09',
+          message: 'This operation is deprecated because it is not used in the codebase',
+        });
+      });
+
+      it('when the message has been marked as deprecated (native support as boolean), the message is marked as deprecated in EventCatalog', async () => {
+        const { getCommand } = utils(catalogDir);
+
+        await plugin(config, { services: [{ path: join(openAPIExamples, 'petstore.yml'), id: 'swagger-petstore' }] });
+
+        const command = await getCommand('createPets');
+
+        expect(command.deprecated).toEqual(true);
+      });
+
       describe('schemas', () => {
         it('when a message has a request body, the request body is the schema of the message', async () => {
           const { getCommand } = utils(catalogDir);

--- a/packages/generator-openapi/src/types.ts
+++ b/packages/generator-openapi/src/types.ts
@@ -27,6 +27,12 @@ export type Operation = {
   extensions?: {
     [key: string]: any;
   };
+  deprecated?:
+    | boolean
+    | {
+        date?: string;
+        message?: string;
+      };
 };
 
 export interface OpenAPIParameter {

--- a/packages/generator-openapi/src/utils/messages.ts
+++ b/packages/generator-openapi/src/utils/messages.ts
@@ -169,5 +169,6 @@ export const buildMessage = async (pathToFile: string, document: OpenAPI.Documen
     sidebar: {
       badge: httpVerb,
     },
+    ...(operation.deprecated ? { deprecated: operation.deprecated } : {}),
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,8 +275,8 @@ importers:
         specifier: ^2.27.7
         version: 2.27.12
       '@eventcatalog/sdk':
-        specifier: ^2.2.4
-        version: 2.2.4
+        specifier: ^2.2.6
+        version: 2.2.6
       chalk:
         specifier: ^4
         version: 4.1.2
@@ -876,6 +876,9 @@ packages:
 
   '@eventcatalog/sdk@2.2.4':
     resolution: { integrity: sha512-+98Bi/+Zb75vsptQgIKuIZpVUMWMudo++1TKCRJI8z4UT3hyFRQ+GxqaLDYehBQ4Gu+Y8pp18m5uleg67Pz0ZQ== }
+
+  '@eventcatalog/sdk@2.2.6':
+    resolution: { integrity: sha512-Sa72fhoNYQeUnd6Y3yARirdYO+NIdahms/4epzH57+dyCXnGwS49j6hGucCM/w6g7Y38LZsYI+ra5NimoF8TUw== }
 
   '@huggingface/jinja@0.3.3':
     resolution: { integrity: sha512-vQQr2JyWvVFba3Lj9es4q9vCl1sAc74fdgnEMoX8qHrXtswap9ge9uO3ONDzQB0cQ0PUyaKY2N6HaVbTBvSXvw== }
@@ -4372,6 +4375,16 @@ snapshots:
       semver: 7.6.3
 
   '@eventcatalog/sdk@2.2.4':
+    dependencies:
+      '@changesets/cli': 2.27.12
+      fs-extra: 11.3.0
+      glob: 11.0.1
+      gray-matter: 4.0.3
+      proper-lockfile: 4.1.2
+      semver: 7.6.3
+      slugify: 1.6.6
+
+  '@eventcatalog/sdk@2.2.6':
     dependencies:
       '@changesets/cli': 2.27.12
       fs-extra: 11.3.0


### PR DESCRIPTION
If fields are marked as `deprecated` in OpenAPI this state is shown in EventCatlaog.