### PR TITLE
fix(plugin): openapi plugin now checks versions before versioning

### DIFF
--- a/.changeset/swift-tools-move.md
+++ b/.changeset/swift-tools-move.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-openapi": patch
+---
+
+fix(plugin): openapi plugin now checks versions before versioning

--- a/.changeset/swift-tools-move.md
+++ b/.changeset/swift-tools-move.md
@@ -1,5 +1,5 @@
 ---
-"@eventcatalog/generator-openapi": patch
+"@eventcatalog/generator-openapi": major
 ---
 
 fix(plugin): openapi plugin now checks versions before versioning

--- a/packages/generator-openapi/package.json
+++ b/packages/generator-openapi/package.json
@@ -21,6 +21,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/lodash": "^4.17.7",
     "@types/node": "^20.16.1",
+    "@types/semver": "^7.7.0",
     "prettier": "^3.3.3",
     "tsup": "^8.1.0",
     "typescript": "^5.5.3",
@@ -40,6 +41,7 @@
     "chalk": "^4",
     "js-yaml": "^4.1.0",
     "openapi-types": "^12.1.3",
+    "semver": "^7.7.2",
     "slugify": "^1.6.6",
     "update-notifier": "^7.3.1"
   }

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -15,6 +15,7 @@ import yaml from 'js-yaml';
 import { join } from 'node:path';
 import pkgJSON from '../package.json';
 import { checkForPackageUpdate } from '../../../shared/check-for-package-update';
+import { isVersionGreaterThan, isVersionLessThan } from './utils/versions';
 
 type MESSAGE_TYPE = 'command' | 'query' | 'event';
 export type HTTP_METHOD = 'POST' | 'GET' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
@@ -140,8 +141,14 @@ export default async (_: any, options: Props) => {
 
       // Check if service is already defined... if the versions do not match then create service.
       const latestServiceInCatalog = await getService(service.id, 'latest');
-      const versionTheService = latestServiceInCatalog && latestServiceInCatalog.version !== version;
+
+      const versionTheService = latestServiceInCatalog && isVersionGreaterThan(version, latestServiceInCatalog.version);
       console.log(chalk.blue(`Processing service: ${document.info.title} (v${version})`));
+
+      // If the version is less than the latest service version, we need to write is a versioned service
+      if (latestServiceInCatalog && isVersionLessThan(version, latestServiceInCatalog.version)) {
+        servicePath = join(servicePath, 'versioned', version);
+      }
 
       // Found a service, and versions do not match, we need to version the one already there
       if (versionTheService) {

--- a/packages/generator-openapi/src/utils/versions.ts
+++ b/packages/generator-openapi/src/utils/versions.ts
@@ -1,11 +1,11 @@
 import { satisfies } from 'semver';
 
 // version is greater than or equal to the given version
-export const isVersionGreaterThanOrEqualTo = (version: string, givenVersion: string) => {
-  return satisfies(version, `>=${givenVersion}`);
+export const isVersionGreaterThan = (version: string, givenVersion: string) => {
+  return satisfies(version, `>${givenVersion}`);
 };
 
 // version is less than or equal to the given version
-export const isVersionLessThanOrEqualTo = (version: string, givenVersion: string) => {
-  return satisfies(version, `<=${givenVersion}`);
+export const isVersionLessThan = (version: string, givenVersion: string) => {
+  return satisfies(version, `<${givenVersion}`);
 };

--- a/packages/generator-openapi/src/utils/versions.ts
+++ b/packages/generator-openapi/src/utils/versions.ts
@@ -1,0 +1,11 @@
+import { satisfies } from 'semver';
+
+// version is greater than or equal to the given version
+export const isVersionGreaterThanOrEqualTo = (version: string, givenVersion: string) => {
+  return satisfies(version, `>=${givenVersion}`);
+};
+
+// version is less than or equal to the given version
+export const isVersionLessThanOrEqualTo = (version: string, givenVersion: string) => {
+  return satisfies(version, `<=${givenVersion}`);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,6 +366,9 @@ importers:
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
+      semver:
+        specifier: ^7.7.2
+        version: 7.7.2
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
@@ -385,6 +388,9 @@ importers:
       '@types/node':
         specifier: ^20.16.1
         version: 20.17.17
+      '@types/semver':
+        specifier: ^7.7.0
+        version: 7.7.0
       prettier:
         specifier: ^3.3.3
         version: 3.4.2
@@ -1592,6 +1598,9 @@ packages:
 
   '@types/retry@0.12.0':
     resolution: { integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA== }
+
+  '@types/semver@7.7.0':
+    resolution: { integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA== }
 
   '@types/update-notifier@6.0.8':
     resolution: { integrity: sha512-IlDFnfSVfYQD+cKIg63DEXn3RFmd7W1iYtKQsJodcHK9R1yr8aKbKaPKfBxzPpcHCq2DU8zUq4PIPmy19Thjfg== }
@@ -2981,6 +2990,11 @@ packages:
     engines: { node: '>=10' }
     hasBin: true
 
+  semver@7.7.2:
+    resolution: { integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA== }
+    engines: { node: '>=10' }
+    hasBin: true
+
   set-function-length@1.2.2:
     resolution: { integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg== }
     engines: { node: '>= 0.4' }
@@ -4205,7 +4219,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.0
+      semver: 7.7.2
 
   '@changesets/assemble-release-plan@6.0.5':
     dependencies:
@@ -4214,7 +4228,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.1
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.0
+      semver: 7.7.2
 
   '@changesets/changelog-git@0.2.0':
     dependencies:
@@ -4247,7 +4261,7 @@ snapshots:
       package-manager-detector: 0.2.9
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.7.0
+      semver: 7.7.2
       spawndamnit: 3.0.1
       term-size: 2.2.1
 
@@ -4270,7 +4284,7 @@ snapshots:
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.0
+      semver: 7.7.2
 
   '@changesets/get-release-plan@4.0.6':
     dependencies:
@@ -5290,6 +5304,8 @@ snapshots:
       undici-types: 6.19.8
 
   '@types/retry@0.12.0': {}
+
+  '@types/semver@7.7.0': {}
 
   '@types/update-notifier@6.0.8':
     dependencies:
@@ -6507,7 +6523,7 @@ snapshots:
       ky: 1.7.5
       registry-auth-token: 5.1.0
       registry-url: 6.0.1
-      semver: 7.7.0
+      semver: 7.7.2
 
   package-manager-detector@0.2.9: {}
 
@@ -6717,6 +6733,8 @@ snapshots:
   semver@7.6.3: {}
 
   semver@7.7.0: {}
+
+  semver@7.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -7084,7 +7102,7 @@ snapshots:
       is-npm: 6.0.0
       latest-version: 9.0.0
       pupa: 3.1.0
-      semver: 7.7.0
+      semver: 7.7.2
       xdg-basedir: 5.1.0
 
   urijs@1.19.11: {}


### PR DESCRIPTION
Fix for #184

We now check the versions of the spec files, when we compare them with what's in the catalog.

If the spec we process version > what we have in the catalog, then we version the previous service (we used to version regardless of version).