### PR TITLE
feat(plugin): asyncpi and openapi now support name and summary override

### DIFF
--- a/.changeset/wise-teachers-jog.md
+++ b/.changeset/wise-teachers-jog.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/generator-asyncapi": patch
+"@eventcatalog/generator-openapi": patch
+---
+
+feat(plugin): asyncpi and openapi now support name and summary override

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -43,6 +43,7 @@ const optionsSchema = z.object({
       path: z.string({ required_error: 'The service path is required. please provide the path to specification file' }),
       draft: z.boolean().optional(),
       name: z.string().optional(),
+      summary: z.string().optional(),
       owners: z.array(z.string()).optional(),
       generateMarkdown: z
         .function()
@@ -527,7 +528,7 @@ export default async (config: any, options: Props) => {
         id: serviceId,
         name: serviceName,
         version: version,
-        summary: getServiceSummary(document),
+        summary: service.summary || getServiceSummary(document),
         badges: badges || documentTags.map((tag) => ({ content: tag.name(), textColor: 'blue', backgroundColor: 'blue' })),
         markdown: serviceMarkdown,
         sends,

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -746,6 +746,23 @@ describe('AsyncAPI EventCatalog Plugin', () => {
           expect(service.name).toEqual('Awesome account service');
         });
 
+        it('[summary] if the `summary` value is given in the service config options, then the service summary is set to the config value', async () => {
+          const { getService } = utils(catalogDir);
+
+          await plugin(config, {
+            services: [
+              {
+                path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'),
+                id: 'account-service',
+                summary: 'Awesome account service summary',
+              },
+            ],
+          });
+
+          const service = await getService('account-service', '1.0.0');
+          expect(service.summary).toEqual('Awesome account service summary');
+        });
+
         it('[id] if the `id` not provided in the service config options, The generator throw an explicit error', async () => {
           await expect(
             plugin(config, {

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import SwaggerParser from '@apidevtools/swagger-parser';
 
 import { defaultMarkdown as generateMarkdownForDomain } from './utils/domains';
-import { buildService } from './utils/services';
+import { buildService, getSummary } from './utils/services';
 import { buildMessage } from './utils/messages';
 import { getOperationsByType } from './utils/openapi';
 import { Domain, Service, Message } from './types';
@@ -210,6 +210,8 @@ export default async (_: any, options: Props) => {
       await writeService(
         {
           ...service,
+          name: serviceSpec.name || service.name,
+          summary: serviceSpec.summary || service.summary,
           badges: serviceBadges || service.badges,
           markdown: serviceMarkdown,
           specifications: serviceSpecifications,

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -801,6 +801,30 @@ describe('OpenAPI EventCatalog Plugin', () => {
             expect(event.draft).toEqual(true);
           });
         });
+        describe('config option: name', () => {
+          it('if a `name` value is given in the service config options, then the generator uses that name as the service name', async () => {
+            const { getService } = utils(catalogDir);
+
+            await plugin(config, {
+              services: [{ path: join(openAPIExamples, 'petstore.yml'), id: 'swagger-petstore', name: 'My Custom Name' }],
+            });
+
+            const service = await getService('swagger-petstore', '1.0.0');
+            expect(service.name).toEqual('My Custom Name');
+          });
+        });
+        describe('config option: summary', () => {
+          it('if a `summary` value is given in the service config options, then the generator uses that summary as the service summary', async () => {
+            const { getService } = utils(catalogDir);
+
+            await plugin(config, {
+              services: [{ path: join(openAPIExamples, 'petstore.yml'), id: 'swagger-petstore', summary: 'My Custom Summary' }],
+            });
+
+            const service = await getService('swagger-petstore', '1.0.0');
+            expect(service.summary).toEqual('My Custom Summary');
+          });
+        });
       });
     });
 

--- a/packages/generator-openapi/src/types.ts
+++ b/packages/generator-openapi/src/types.ts
@@ -11,6 +11,8 @@ export type Domain = {
 
 export type Service = {
   id: string;
+  name?: string;
+  summary?: string;
   path: string | string[];
   owners?: string[];
   setMessageOwnersToServiceOwners?: boolean;


### PR DESCRIPTION
Users using the AsyncAPI and OpenAPI plugins can now override the `name` and `summary` fields using the generator.

If none are provided, they will default back to the specification (how they were before).