### PR TITLE
fix(openapi): folder names for messages are now correct

### DIFF
--- a/.changeset/ten-news-brush.md
+++ b/.changeset/ten-news-brush.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-openapi": patch
+---
+
+fix(openapi): folder names for messages are now correct

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -278,7 +278,7 @@ const processMessagesForOpenAPISpec = async (
 
   // Go through all messages
   for (const operation of operations) {
-    const { requestBodiesAndResponses, sidebar, ...message } = await buildMessage(
+    const { requestBodiesAndResponses, sidebar, messageFolderName, ...message } = await buildMessage(
       pathToSpec,
       document,
       operation,
@@ -322,7 +322,8 @@ const processMessagesForOpenAPISpec = async (
       }
     }
 
-    let messagePath = join(servicePath, folder, message.id);
+    let messagePath = join(servicePath, folder, messageFolderName);
+
     if (options.writeFilesToRoot) {
       messagePath = message.id;
     }

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -1254,6 +1254,9 @@ describe('OpenAPI EventCatalog Plugin', () => {
           const command = await getCommand('petstore-createPets');
 
           expect(command.id).toEqual('petstore-createPets');
+
+          // Make sure folder name is also prefixed with the service id
+          expect(existsSync(join(catalogDir, 'services', 'petstore', 'commands', 'createPets'))).toBe(true);
         });
 
         it('if a `messages.id.separator` value is given then the that separator is used to join the prefix and the message id', async () => {

--- a/packages/generator-openapi/src/utils/messages.ts
+++ b/packages/generator-openapi/src/utils/messages.ts
@@ -195,6 +195,9 @@ export const buildMessage = async (
     uniqueIdentifier = [messageIdConfig.prefix, uniqueIdentifier].join(separator);
   }
 
+  // Put this before the prefixWithServiceId check so that the folder name is the same as the id
+  const messageFolderName = extensions['x-eventcatalog-message-id'] || uniqueIdentifier;
+
   if (messageIdConfig?.prefixWithServiceId) {
     const separator = messageIdConfig.separator || '-';
     uniqueIdentifier = [serviceId, uniqueIdentifier].join(separator);
@@ -214,6 +217,7 @@ export const buildMessage = async (
     sidebar: {
       badge: httpVerb,
     },
+    messageFolderName,
     ...(extensions['x-eventcatalog-draft'] ? { draft: true } : {}),
     ...(operation.deprecated ? { deprecated: operation.deprecated } : {}),
   };


### PR DESCRIPTION
Fixed an issue introduced by #235. 

The folder names for messages are now rendered correctly (Without the service id as the prefix value).