### PR TITLE
fix(generators): persist diagrams property during service regeneration

### DIFF
--- a/.changeset/gentle-waves-persist.md
+++ b/.changeset/gentle-waves-persist.md
@@ -1,0 +1,6 @@
+---
+'@eventcatalog/generator-openapi': patch
+'@eventcatalog/generator-asyncapi': patch
+---
+
+Persist diagrams property during service regeneration (fixes event-catalog/eventcatalog#2056)

--- a/packages/generator-asyncapi/package.json
+++ b/packages/generator-asyncapi/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@asyncapi/avro-schema-parser": "3.0.24",
     "@asyncapi/parser": "3.4.0",
-    "@eventcatalog/sdk": "2.9.6",
+    "@eventcatalog/sdk": "2.12.1",
     "chalk": "4.1.2",
     "fs-extra": "^11.2.0",
     "glob": "^11.0.0",

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -258,6 +258,7 @@ export default async (config: any, options: Props) => {
     let repository = null;
     let badges = null;
     let attachments = null;
+    let diagrams = null;
 
     let serviceSpecifications: any = {};
     let serviceSpecificationsFiles: Array<{ fileName: string; content: string }> = [];
@@ -531,6 +532,7 @@ export default async (config: any, options: Props) => {
       styles = latestServiceInCatalog.styles || null;
       badges = latestServiceInCatalog.badges || null;
       attachments = latestServiceInCatalog.attachments || null;
+      diagrams = latestServiceInCatalog.diagrams || null;
       // persist writesTo and readsFrom
       serviceWritesTo = latestServiceInCatalog.writesTo ? latestServiceInCatalog.writesTo : configuredWritesTo;
       serviceReadsFrom = latestServiceInCatalog.readsFrom ? latestServiceInCatalog.readsFrom : configuredReadsFrom;
@@ -574,6 +576,7 @@ export default async (config: any, options: Props) => {
         ...(owners && { owners }),
         ...(repository && { repository }),
         ...(styles && { styles }),
+        ...(diagrams && { diagrams }),
         ...(isServiceMarkedAsDraft && { draft: true }),
         ...(attachments && { attachments }),
         ...(serviceWritesTo.length > 0 ? { writesTo: serviceWritesTo } : {}),

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -2147,6 +2147,45 @@ describe('AsyncAPI EventCatalog Plugin', () => {
           })
         );
       });
+
+      it('when the AsyncAPI service is already defined in EventCatalog and the versions match, the diagrams are persisted and not overwritten', async () => {
+        // Create a service with the same name and version as the AsyncAPI file for testing
+        const { writeService, getService } = utils(catalogDir);
+
+        await writeService({
+          id: 'account-service-diagrams',
+          version: '1.0.0',
+          name: 'Random Name',
+          markdown: 'Here is my original markdown, please do not override this!',
+          diagrams: [
+            {
+              id: 'my-custom-diagram',
+              title: 'My Custom Diagram',
+            },
+          ],
+        });
+
+        await plugin(config, {
+          services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service-diagrams' }],
+        });
+
+        const service = await getService('account-service-diagrams', '1.0.0');
+        expect(service).toEqual(
+          expect.objectContaining({
+            id: 'account-service-diagrams',
+            name: 'Account Service',
+            version: '1.0.0',
+            summary: 'This service is in charge of processing user signups',
+            markdown: 'Here is my original markdown, please do not override this!',
+            diagrams: [
+              {
+                id: 'my-custom-diagram',
+                title: 'My Custom Diagram',
+              },
+            ],
+          })
+        );
+      });
     });
   });
 });

--- a/packages/generator-openapi/package.json
+++ b/packages/generator-openapi/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
     "@changesets/cli": "^2.27.7",
-    "@eventcatalog/sdk": "^2.9.6",
+    "@eventcatalog/sdk": "2.12.1",
     "chalk": "4.1.2",
     "js-yaml": "^4.1.0",
     "openapi-types": "^12.1.3",

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -249,6 +249,7 @@ export default async (_: any, options: Props) => {
       let owners = service.owners || [];
       let repository = null;
       let styles = null;
+      let serviceDiagrams = null;
       let serviceWritesTo = configuredWritesTo;
       let serviceReadsFrom = configuredReadsFrom;
 
@@ -265,6 +266,7 @@ export default async (_: any, options: Props) => {
         styles = latestServiceInCatalog.styles || null;
         serviceBadges = latestServiceInCatalog.badges || null;
         serviceAttachments = latestServiceInCatalog.attachments || null;
+        serviceDiagrams = latestServiceInCatalog.diagrams || null;
         serviceWritesTo = latestServiceInCatalog.writesTo || ([] as any);
         serviceReadsFrom = latestServiceInCatalog.readsFrom || ([] as any);
         // persist any specifications that are already in the catalog, preserving format (array or object)
@@ -302,6 +304,7 @@ export default async (_: any, options: Props) => {
           ...(owners ? { owners } : {}),
           ...(repository ? { repository } : {}),
           ...(styles ? { styles } : {}),
+          ...(serviceDiagrams ? { diagrams: serviceDiagrams } : {}),
           ...(isServiceMarkedAsDraft ? { draft: true } : {}),
           ...(serviceAttachments ? { attachments: serviceAttachments } : {}),
           ...(serviceWritesTo.length > 0 ? { writesTo: serviceWritesTo } : {}),

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -1879,6 +1879,46 @@ describe('OpenAPI EventCatalog Plugin', () => {
           })
         );
       });
+
+      it('when the OpenAPI service is already defined in EventCatalog and the versions match, the diagrams are persisted and not overwritten', async () => {
+        // Create a service with the same name and version as the OpenAPI file for testing
+        const { writeService, getService } = utils(catalogDir);
+
+        await writeService(
+          {
+            id: 'swagger-petstore-diagrams',
+            version: '1.0.0',
+            name: 'Random Name',
+            markdown: 'Here is my original markdown, please do not override this!',
+            diagrams: [
+              {
+                id: 'my-custom-diagram',
+                title: 'My Custom Diagram',
+              },
+            ],
+          },
+          { path: 'Swagger Petstore' }
+        );
+
+        await plugin(config, { services: [{ path: join(openAPIExamples, 'petstore.yml'), id: 'swagger-petstore-diagrams' }] });
+
+        const service = await getService('swagger-petstore-diagrams', '1.0.0');
+        expect(service).toEqual(
+          expect.objectContaining({
+            id: 'swagger-petstore-diagrams',
+            name: 'Swagger Petstore',
+            version: '1.0.0',
+            summary: 'This is a sample server Petstore server.',
+            markdown: 'Here is my original markdown, please do not override this!',
+            diagrams: [
+              {
+                id: 'my-custom-diagram',
+                title: 'My Custom Diagram',
+              },
+            ],
+          })
+        );
+      });
     });
 
     describe('parsing multiple OpenAPI files to the same service', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,8 +174,8 @@ importers:
         specifier: 3.4.0
         version: 3.4.0
       '@eventcatalog/sdk':
-        specifier: 2.9.6
-        version: 2.9.6(@types/node@20.19.1)
+        specifier: 2.12.1
+        version: 2.12.1(@types/node@20.19.1)
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -192,8 +192,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
+        specifier: ^4.17.23
+        version: 4.17.23
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
@@ -506,8 +506,8 @@ importers:
         specifier: ^2.27.7
         version: 2.29.5
       '@eventcatalog/sdk':
-        specifier: ^2.9.6
-        version: 2.9.6(@types/node@20.19.1)
+        specifier: 2.12.1
+        version: 2.12.1(@types/node@20.19.1)
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -824,6 +824,9 @@ packages:
   '@changesets/apply-release-plan@7.0.12':
     resolution: { integrity: sha512-EaET7As5CeuhTzvXTQCRZeBUcisoYPDDcXvgTE/2jmmypKp0RC7LxKj/yzqeh/1qFTZI7oDGFcL1PHRuQuketQ== }
 
+  '@changesets/apply-release-plan@7.0.14':
+    resolution: { integrity: sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA== }
+
   '@changesets/assemble-release-plan@6.0.9':
     resolution: { integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ== }
 
@@ -838,8 +841,15 @@ packages:
     resolution: { integrity: sha512-6qCcVsIG1KQLhpQ5zE8N0PckIx4+9QlHK3z6/lwKnw7Tir71Bjw8BeOZaxA/4Jt00pcgCnCSWZnyuZf5Il05QQ== }
     hasBin: true
 
+  '@changesets/cli@2.29.8':
+    resolution: { integrity: sha512-1weuGZpP63YWUYjay/E84qqwcnt5yJMM0tep10Up7Q5cS/DGe2IZ0Uj3HNMxGhCINZuR7aO9WBMdKnPit5ZDPA== }
+    hasBin: true
+
   '@changesets/config@3.1.1':
     resolution: { integrity: sha512-bd+3Ap2TKXxljCggI0mKPfzCQKeV/TU4yO2h2C6vAihIo8tzseAn2e7klSuiyYYXvgu53zMN1OeYMIQkaQoWnA== }
+
+  '@changesets/config@3.1.2':
+    resolution: { integrity: sha512-CYiRhA4bWKemdYi/uwImjPxqWNpqGPNbEBdX1BdONALFIDK7MCUj6FPkzD+z9gJcvDFUQJn9aDVf4UG7OT6Kog== }
 
   '@changesets/errors@0.2.0':
     resolution: { integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow== }
@@ -849,6 +859,9 @@ packages:
 
   '@changesets/get-release-plan@4.0.13':
     resolution: { integrity: sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg== }
+
+  '@changesets/get-release-plan@4.0.14':
+    resolution: { integrity: sha512-yjZMHpUHgl4Xl5gRlolVuxDkm4HgSJqT93Ri1Uz8kGrQb+5iJ8dkXJ20M2j/Y4iV5QzS2c5SeTxVSKX+2eMI0g== }
 
   '@changesets/get-version-range-type@0.4.0':
     resolution: { integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ== }
@@ -862,11 +875,17 @@ packages:
   '@changesets/parse@0.4.1':
     resolution: { integrity: sha512-iwksMs5Bf/wUItfcg+OXrEpravm5rEd9Bf4oyIPL4kVTmJQ7PNDSd6MDYkpSJR1pn7tz/k8Zf2DhTCqX08Ou+Q== }
 
+  '@changesets/parse@0.4.2':
+    resolution: { integrity: sha512-Uo5MC5mfg4OM0jU3up66fmSn6/NE9INK+8/Vn/7sMVcdWg46zfbvvUSjD9EMonVqPi9fbrJH9SXHn48Tr1f2yA== }
+
   '@changesets/pre@2.0.2':
     resolution: { integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug== }
 
   '@changesets/read@0.6.5':
     resolution: { integrity: sha512-UPzNGhsSjHD3Veb0xO/MwvasGe8eMyNrR/sT9gR8Q3DhOQZirgKhhXv/8hVsI0QpPjR004Z9iFxoJU6in3uGMg== }
+
+  '@changesets/read@0.6.6':
+    resolution: { integrity: sha512-P5QaN9hJSQQKJShzzpBT13FzOSPyHbqdoIBUd2DJdgvnECCyO6LmAOWSV+O8se2TaZJVwSXjL+v9yhb+a9JeJg== }
 
   '@changesets/should-skip-package@0.1.2':
     resolution: { integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw== }
@@ -1180,6 +1199,10 @@ packages:
   '@eventcatalog/license@0.0.7':
     resolution: { integrity: sha512-izSIn3Dfc6LTcPiA89EqZ4/l5WCitLxt0XVu2yilyaibMOioxW7ABRFZY8/Azocd6ULKseVA2lCcoeT35/GRcg== }
     engines: { node: '>=16.0.0' }
+
+  '@eventcatalog/sdk@2.12.1':
+    resolution: { integrity: sha512-N/Xz1jniwwUyq9tb97VXmLj0FJrULqnSZVtLBqhOaJUSJkfwnu4WIoeQN5eDK2cVYVi812eBR3xKfCNbErCiJw== }
+    hasBin: true
 
   '@eventcatalog/sdk@2.9.6':
     resolution: { integrity: sha512-u1/IlS82Su55IJgJivzi5eZp1nfW6Lpf5PPhw1/q3EVlhVDZbEVDVuYtgQlnIGLDi144m4QKtzYCHI8824icLQ== }
@@ -2288,6 +2311,10 @@ packages:
     resolution: { integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg== }
     engines: { node: '>= 0.8' }
 
+  commander@12.1.0:
+    resolution: { integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA== }
+    engines: { node: '>=18' }
+
   commander@4.1.1:
     resolution: { integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA== }
     engines: { node: '>= 6' }
@@ -2569,6 +2596,10 @@ packages:
 
   fs-extra@11.3.0:
     resolution: { integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew== }
+    engines: { node: '>=14.14' }
+
+  fs-extra@11.3.3:
+    resolution: { integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg== }
     engines: { node: '>=14.14' }
 
   fs-extra@7.0.1:
@@ -2892,6 +2923,10 @@ packages:
     resolution: { integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA== }
     hasBin: true
 
+  js-yaml@4.1.1:
+    resolution: { integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA== }
+    hasBin: true
+
   jsep@1.4.0:
     resolution: { integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw== }
     engines: { node: '>= 10.16.0' }
@@ -3028,6 +3063,9 @@ packages:
 
   lodash@4.17.21:
     resolution: { integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg== }
+
+  lodash@4.17.23:
+    resolution: { integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w== }
 
   long@5.3.2:
     resolution: { integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA== }
@@ -3476,6 +3514,11 @@ packages:
 
   semver@7.7.2:
     resolution: { integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA== }
+    engines: { node: '>=10' }
+    hasBin: true
+
+  semver@7.7.3:
+    resolution: { integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q== }
     engines: { node: '>=10' }
     hasBin: true
 
@@ -4877,6 +4920,22 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.2
 
+  '@changesets/apply-release-plan@7.0.14':
+    dependencies:
+      '@changesets/config': 3.1.2
+      '@changesets/get-version-range-type': 0.4.0
+      '@changesets/git': 3.0.4
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      detect-indent: 6.1.0
+      fs-extra: 7.0.1
+      lodash.startcase: 4.4.0
+      outdent: 0.5.0
+      prettier: 2.8.8
+      resolve-from: 5.0.0
+      semver: 7.7.3
+
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
       '@changesets/errors': 0.2.0
@@ -4954,7 +5013,50 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@changesets/cli@2.29.8(@types/node@20.19.1)':
+    dependencies:
+      '@changesets/apply-release-plan': 7.0.14
+      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/changelog-git': 0.2.1
+      '@changesets/config': 3.1.2
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/get-release-plan': 4.0.14
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.6
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@changesets/write': 0.4.0
+      '@inquirer/external-editor': 1.0.3(@types/node@20.19.1)
+      '@manypkg/get-packages': 1.1.3
+      ansi-colors: 4.1.3
+      ci-info: 3.9.0
+      enquirer: 2.4.1
+      fs-extra: 7.0.1
+      mri: 1.2.0
+      p-limit: 2.3.0
+      package-manager-detector: 0.2.11
+      picocolors: 1.1.1
+      resolve-from: 5.0.0
+      semver: 7.7.3
+      spawndamnit: 3.0.1
+      term-size: 2.2.1
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@changesets/config@3.1.1':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/logger': 0.1.1
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+      micromatch: 4.0.8
+
+  '@changesets/config@3.1.2':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -4984,6 +5086,15 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
 
+  '@changesets/get-release-plan@4.0.14':
+    dependencies:
+      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/config': 3.1.2
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.6
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+
   '@changesets/get-version-range-type@0.4.0': {}
 
   '@changesets/git@3.0.4':
@@ -5003,6 +5114,11 @@ snapshots:
       '@changesets/types': 6.1.0
       js-yaml: 3.14.1
 
+  '@changesets/parse@0.4.2':
+    dependencies:
+      '@changesets/types': 6.1.0
+      js-yaml: 4.1.1
+
   '@changesets/pre@2.0.2':
     dependencies:
       '@changesets/errors': 0.2.0
@@ -5015,6 +5131,16 @@ snapshots:
       '@changesets/git': 3.0.4
       '@changesets/logger': 0.1.1
       '@changesets/parse': 0.4.1
+      '@changesets/types': 6.1.0
+      fs-extra: 7.0.1
+      p-filter: 2.1.0
+      picocolors: 1.1.1
+
+  '@changesets/read@0.6.6':
+    dependencies:
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/parse': 0.4.2
       '@changesets/types': 6.1.0
       fs-extra: 7.0.1
       p-filter: 2.1.0
@@ -5226,6 +5352,19 @@ snapshots:
       jose: 5.10.0
     transitivePeerDependencies:
       - supports-color
+
+  '@eventcatalog/sdk@2.12.1(@types/node@20.19.1)':
+    dependencies:
+      '@changesets/cli': 2.29.8(@types/node@20.19.1)
+      commander: 12.1.0
+      fs-extra: 11.3.3
+      glob: 11.1.0
+      gray-matter: 4.0.3
+      proper-lockfile: 4.1.2
+      semver: 7.7.3
+      slugify: 1.6.6
+    transitivePeerDependencies:
+      - '@types/node'
 
   '@eventcatalog/sdk@2.9.6(@types/node@20.19.1)':
     dependencies:
@@ -6107,7 +6246,7 @@ snapshots:
       dependency-graph: 0.11.0
       fast-memoize: 2.5.2
       immer: 9.0.21
-      lodash: 4.17.21
+      lodash: 4.17.23
       tslib: 2.8.1
       urijs: 1.19.11
 
@@ -6117,7 +6256,7 @@ snapshots:
       '@stoplight/path': 1.3.2
       '@stoplight/types': 13.20.0
       jsonc-parser: 2.2.1
-      lodash: 4.17.21
+      lodash: 4.17.23
       safe-stable-stringify: 1.1.1
 
   '@stoplight/ordered-object-literal@1.0.5': {}
@@ -6140,7 +6279,7 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.17.1)
       es-aggregate-error: 1.0.14
       jsonpath-plus: 10.3.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       lodash.topath: 4.5.2
       minimatch: 3.1.2
       nimma: 0.2.3
@@ -6170,7 +6309,7 @@ snapshots:
       ajv-draft-04: 1.0.0(ajv@8.17.1)
       ajv-errors: 3.0.0(ajv@8.17.1)
       ajv-formats: 2.1.1(ajv@8.17.1)
-      lodash: 4.17.21
+      lodash: 4.17.23
       tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
@@ -6198,7 +6337,7 @@ snapshots:
       '@stoplight/path': 1.3.2
       '@stoplight/types': 13.20.0
       abort-controller: 3.0.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       node-fetch: 2.7.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -6551,6 +6690,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@12.1.0: {}
 
   commander@4.1.1: {}
 
@@ -6925,6 +7066,12 @@ snapshots:
       jsonfile: 6.1.0
       universalify: 2.0.1
 
+  fs-extra@11.3.3:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -7268,6 +7415,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
   jsep@1.4.0: {}
 
   json-schema-traverse@1.0.0: {}
@@ -7353,6 +7504,8 @@ snapshots:
   lodash.topath@4.5.2: {}
 
   lodash@4.17.21: {}
+
+  lodash@4.17.23: {}
 
   long@5.3.2: {}
 
@@ -7785,6 +7938,8 @@ snapshots:
   semver@7.6.3: {}
 
   semver@7.7.2: {}
+
+  semver@7.7.3: {}
 
   serialize-error@7.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes https://github.com/event-catalog/eventcatalog/issues/2056

When services with diagram references in their frontmatter were regenerated using OpenAPI or AsyncAPI generators, the `diagrams` section was removed. This PR ensures the `diagrams` property is persisted during reruns, similar to how `markdown`, `badges`, `attachments`, `styles`, and other properties are already preserved.

## Changes Overview

### Key Changes

- **OpenAPI Generator**: Added `serviceDiagrams` variable and persistence logic to preserve diagrams when service already exists
- **AsyncAPI Generator**: Added `diagrams` variable and persistence logic to preserve diagrams when service already exists
- **Tests**: Added tests for both generators to verify diagrams are persisted and not overwritten during regeneration
- **SDK Update**: Updated `@eventcatalog/sdk` to 2.12.1 in both generators

## How It Works

When the generator runs and finds an existing service with the same version:
1. It fetches the existing service data including `diagrams`
2. The `diagrams` property is preserved: `diagrams = latestServiceInCatalog.diagrams || null`
3. When writing the service, diagrams are included: `...(diagrams && { diagrams })`

This follows the same pattern already used for `styles`, `badges`, `attachments`, and other persisted properties.

## Breaking Changes

None

## Test Plan

- [x] Added test for OpenAPI generator: "when the OpenAPI service is already defined in EventCatalog and the versions match, the diagrams are persisted and not overwritten"
- [x] Added test for AsyncAPI generator: "when the AsyncAPI service is already defined in EventCatalog and the versions match, the diagrams are persisted and not overwritten"
- [x] All 191 tests pass (90 OpenAPI + 101 AsyncAPI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)