### PR TITLE
fix(generator-openapi): resolve schemas/params when operationId is missing

### DIFF
--- a/.changeset/serious-pigs-hunt.md
+++ b/.changeset/serious-pigs-hunt.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-openapi": patch
+---
+
+fix(generator-openapi): resolve schemas/params when operationId is missing

--- a/packages/generator-openapi/src/types.ts
+++ b/packages/generator-openapi/src/types.ts
@@ -43,7 +43,7 @@ export type Message = {
 export type Operation = {
   path: string;
   method: string;
-  operationId: string;
+  operationId?: string;
   summary?: string;
   description?: string;
   type: string;

--- a/packages/generator-openapi/src/utils/messages.ts
+++ b/packages/generator-openapi/src/utils/messages.ts
@@ -170,7 +170,10 @@ export const buildMessage = async (
   serviceVersion?: string
 ) => {
   // Pass the document to avoid re-parsing (needed for authenticated URLs)
-  const requestBodiesAndResponses = await getSchemasByOperationId(pathToFile, operation.operationId, document as any);
+  const requestBodiesAndResponses = await getSchemasByOperationId(pathToFile, operation.operationId, document as any, {
+    path: operation.path,
+    method: operation.method,
+  });
   const extensions = operation.extensions || {};
 
   const operationTags = operation.tags.map((badge) => ({


### PR DESCRIPTION
## Summary
- fix OpenAPI schema/parameter lookup when `operationId` is missing
- keep existing lookup by `operationId` when present
- add fallback lookup by `path + method` for operations without IDs
- add regression test ensuring no-operationId endpoints get correct schemas and parameter sections

## Why
Issue #219 reports that missing operation IDs can lead to incorrect or missing schemas/parameters. The previous lookup used only `operationId`, which can be undefined across multiple operations.

This change makes schema extraction deterministic for no-operationId specs.

## Tests
- `corepack pnpm --filter @eventcatalog/generator-openapi format`
- `corepack pnpm --filter @eventcatalog/generator-openapi test -- --run`
- `corepack pnpm --filter @eventcatalog/generator-openapi build`

## Related
- Closes https://github.com/event-catalog/generators/issues/219
