### PR TITLE
feat(openapi): add operation frontmatter to generated messages

### DIFF
--- a/.changeset/bright-dolphins-dance.md
+++ b/.changeset/bright-dolphins-dance.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/generator-openapi': minor
+---
+
+Add operation frontmatter (method, path, statusCodes) to OpenAPI-generated messages

--- a/packages/generator-openapi/src/utils/messages.ts
+++ b/packages/generator-openapi/src/utils/messages.ts
@@ -206,6 +206,23 @@ export const buildMessage = async (
     uniqueIdentifier = [serviceId, uniqueIdentifier].join(separator);
   }
 
+  // Build the operation frontmatter (method, path, statusCodes)
+  const validOperationMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'];
+  const operationMethod = operation.method.toUpperCase();
+  let operationFrontmatter: { method?: string; path?: string; statusCodes?: string[] } | undefined;
+
+  if (validOperationMethods.includes(operationMethod)) {
+    const statusCodes = requestBodiesAndResponses?.responses
+      ? Object.keys(requestBodiesAndResponses.responses).filter((code) => code !== 'default')
+      : [];
+
+    operationFrontmatter = {
+      method: operationMethod as 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
+      path: operation.path,
+      ...(statusCodes.length > 0 ? { statusCodes } : {}),
+    };
+  }
+
   return {
     id: extensions['x-eventcatalog-message-id'] || uniqueIdentifier,
     version: messageVersion,
@@ -223,5 +240,6 @@ export const buildMessage = async (
     messageName,
     ...(extensions['x-eventcatalog-draft'] ? { draft: true } : {}),
     ...(operation.deprecated ? { deprecated: operation.deprecated } : {}),
+    ...(operationFrontmatter ? { operation: operationFrontmatter } : {}),
   };
 };


### PR DESCRIPTION
## Summary

- Adds `operation` frontmatter (method, path, statusCodes) to OpenAPI-generated messages (commands, queries, events)
- Status codes are extracted from response definitions, excluding `default` responses
- Operation frontmatter is always overridden from the OpenAPI spec on regeneration (not persisted from existing messages)

## Test plan

- [x] Tests for POST, GET, PUT, DELETE operations
- [x] Test that statusCodes excludes `default` response code
- [x] Test that operation frontmatter is overridden on regeneration
- [x] Test for event messages with operation frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)