### PR TITLE
fix(generator-eventbridge): migrate service to root when writeToRoot is enabled

### DIFF
--- a/.changeset/writeToRoot-migrates-service.md
+++ b/.changeset/writeToRoot-migrates-service.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-eventbridge": patch
+---
+
+Fix `writeToRoot` / `writeFilesToRoot`: when an existing service is nested under a domain or subdomain and the option is later enabled, the service is now moved to the root `/services` folder instead of leaving a stale copy behind.

--- a/packages/generator-eventbridge/src/index.ts
+++ b/packages/generator-eventbridge/src/index.ts
@@ -19,6 +19,7 @@ import { generatedMarkdownByEventBus } from './utils/channel';
 import { parse } from '@aws-sdk/util-arn-parser';
 import { DescribeEventBusCommand, EventBridgeClient } from '@aws-sdk/client-eventbridge';
 import path, { join } from 'node:path';
+import fs from 'node:fs/promises';
 import pkgJSON from '../package.json';
 import { checkForPackageUpdate } from '../../../shared/check-for-package-update';
 
@@ -295,6 +296,18 @@ export default async (config: EventCatalogConfig, options: GeneratorProps) => {
         );
         // Removed rmServiceById - writeService with override:true handles overwriting
         // and rmServiceById deletes the entire directory including child resources (e.g. containers)
+      }
+    }
+
+    // If writing to root but the existing service is nested under a domain/subdomain,
+    // remove the stale nested copy so the service is effectively moved to the root.
+    // See https://github.com/event-catalog/eventcatalog/issues/2394
+    if (latestServiceInCatalog && (options.writeFilesToRoot || service.writeToRoot)) {
+      const existingServicePath = await getResourcePath(eventCatalogDirectory, service.id, latestServiceInCatalog.version);
+      const expectedRootDir = path.join(path.sep, 'services', service.id);
+      if (existingServicePath && existingServicePath.directory !== expectedRootDir) {
+        await fs.rm(path.join(eventCatalogDirectory, existingServicePath.directory), { recursive: true, force: true });
+        console.log(chalk.cyan(` - Moved service (${service.id}) to the root /services folder`));
       }
     }
 

--- a/packages/generator-eventbridge/src/test/plugin.test.ts
+++ b/packages/generator-eventbridge/src/test/plugin.test.ts
@@ -1210,6 +1210,99 @@ describe('EventBridge EventCatalog Plugin', () => {
       const services = await fs.readdir(path.join(catalogDir, 'services'));
       expect(services).toEqual(['Orders Service']);
     });
+
+    // Reproduces https://github.com/event-catalog/eventcatalog/issues/2394
+    it('when a service has writeToRoot: true and the domain is a subdomain, the service is written to the root /services folder (not under the subdomain)', async () => {
+      const { writeDomain, addSubDomainToDomain } = utils(catalogDir);
+
+      const subdomainDir = join(catalogDir, 'domains', 'Buyer', 'subdomains', 'Agency');
+      await fs.mkdir(subdomainDir, { recursive: true });
+      await fs.writeFile(join(subdomainDir, 'index.mdx'), '---\nid: Agency\nname: Agency Domain\nversion: 1.0.0\n---\n');
+
+      await writeDomain({
+        id: 'Buyer',
+        name: 'Buyer Domain',
+        version: '1.0.0',
+        markdown: '',
+      });
+
+      await addSubDomainToDomain('Buyer', { id: 'Agency', version: '1.0.0' });
+
+      await plugin(config, {
+        region: 'us-east-1',
+        registryName: 'discovered-schemas',
+        services: [{ id: 'Orders Service', version: '1.0.0', sends: [{ prefix: 'myapp.orders' }], writeToRoot: true }],
+        domain: { id: 'Agency', name: 'Agency Domain', version: '1.0.0' },
+      });
+
+      // Service should exist at the catalog root /services folder
+      const rootServices = await fs.readdir(path.join(catalogDir, 'services'));
+      expect(rootServices).toContain('Orders Service');
+
+      // And should NOT exist under the subdomain path
+      const subdomainServicePath = path.join(
+        catalogDir,
+        'domains',
+        'Buyer',
+        'subdomains',
+        'Agency',
+        'services',
+        'Orders Service'
+      );
+      expect(existsSync(subdomainServicePath)).toBe(false);
+    });
+
+    // Reproduces https://github.com/event-catalog/eventcatalog/issues/2394
+    // Scenario: service was previously generated under a subdomain (no writeToRoot).
+    // User later adds writeToRoot: true and re-runs generate.
+    it('when a service was previously written under a subdomain and writeToRoot: true is then set, the service is moved to the root /services folder', async () => {
+      const { writeDomain, addSubDomainToDomain } = utils(catalogDir);
+
+      const subdomainDir = join(catalogDir, 'domains', 'Buyer', 'subdomains', 'Agency');
+      await fs.mkdir(subdomainDir, { recursive: true });
+      await fs.writeFile(join(subdomainDir, 'index.mdx'), '---\nid: Agency\nname: Agency Domain\nversion: 1.0.0\n---\n');
+
+      await writeDomain({
+        id: 'Buyer',
+        name: 'Buyer Domain',
+        version: '1.0.0',
+        markdown: '',
+      });
+
+      await addSubDomainToDomain('Buyer', { id: 'Agency', version: '1.0.0' });
+
+      // First run: service is generated nested under the subdomain
+      await plugin(config, {
+        region: 'us-east-1',
+        registryName: 'discovered-schemas',
+        services: [{ id: 'Orders Service', version: '1.0.0', sends: [{ prefix: 'myapp.orders' }] }],
+        domain: { id: 'Agency', name: 'Agency Domain', version: '1.0.0' },
+      });
+
+      const subdomainServicePath = path.join(
+        catalogDir,
+        'domains',
+        'Buyer',
+        'subdomains',
+        'Agency',
+        'services',
+        'Orders Service'
+      );
+      expect(existsSync(subdomainServicePath)).toBe(true);
+
+      // Second run: user now sets writeToRoot: true
+      await plugin(config, {
+        region: 'us-east-1',
+        registryName: 'discovered-schemas',
+        services: [{ id: 'Orders Service', version: '1.0.0', sends: [{ prefix: 'myapp.orders' }], writeToRoot: true }],
+        domain: { id: 'Agency', name: 'Agency Domain', version: '1.0.0' },
+      });
+
+      // Expected: service now lives at the root /services folder and is removed from the subdomain
+      const rootServices = await fs.readdir(path.join(catalogDir, 'services'));
+      expect(rootServices).toContain('Orders Service');
+      expect(existsSync(subdomainServicePath)).toBe(false);
+    });
   });
 
   describe('events', () => {


### PR DESCRIPTION
Fixes [event-catalog/eventcatalog#2394](https://github.com/event-catalog/eventcatalog/issues/2394)

## What This PR Does

The EventBridge generator's `writeToRoot` / `writeFilesToRoot` option did not take effect when a service had previously been generated under a domain or subdomain. The generator would correctly write the new service to `/services/<id>`, but left the stale nested copy behind, so the service kept appearing under its original domain. This PR removes the nested copy when the option is enabled so the service is effectively relocated to the root.

## Changes Overview

### Key Changes

- On each run, if `writeFilesToRoot` or `service.writeToRoot` is set and the service already exists at a non-root location (via `getResourcePath`), delete the stale service directory before writing to `/services/<id>`.
- Added `fs/promises` import in `generator-eventbridge/src/index.ts`.
- Added two tests covering the hierarchical subdomain scenario from the issue: one for a clean catalog, one reproducing the reported "services continue to be written to their parent domain" case.

## How It Works

After resolving the `servicePath` and looking up `latestServiceInCatalog`, we check whether `writeToRoot` is in effect. If it is and `getResourcePath` returns a directory other than `/services/<id>`, we `fs.rm` that directory (recursive, force) so `writeService` produces a single copy at the root. The existing behaviour for services already at the root, or services not yet written, is unchanged.

## Breaking Changes

None.

## Additional Notes

- The SDK's `rmServiceById` was deliberately not reused here because it also deletes child resources (e.g. containers); `fs.rm` on the resolved directory is sufficient and consistent with the move-to-root semantics.
- Same logic applies to both `options.writeFilesToRoot` (global) and `service.writeToRoot` (per-service).