### PR TITLE
fix(generator-openapi): generate schemas for operations without operationId

### DIFF
--- a/.changeset/clever-foxes-leap.md
+++ b/.changeset/clever-foxes-leap.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/generator-openapi': patch
+---
+
+Fix: schemas, parameters, and request bodies are now correctly generated per-operation when OpenAPI specs omit `operationId`. Previously all operation-id-less operations received the first such operation's schemas due to `undefined === undefined` matching.

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -1576,6 +1576,52 @@ describe('OpenAPI EventCatalog Plugin', () => {
           expect(command.markdown).toContain(`### Parameters
 - **limit** (query): How many items to return at one time (max 100)`);
         });
+
+        // Regression test for https://github.com/event-catalog/generators/issues/219
+        it('when operations have no operationId, each message still gets its own schemas, parameters, and request bodies', async () => {
+          const { getQuery, getCommand } = utils(catalogDir);
+
+          await plugin(config, {
+            services: [{ path: join(openAPIExamples, 'without-operationIds.yml'), id: 'product-api' }],
+          });
+
+          // GET /{productId} — should expose its productId path parameter
+          const getProductById = await getQuery('product-api_GET_{productId}');
+          expect(getProductById.markdown).toContain('- **productId** (path)');
+
+          // GET /{productId}/reviews — should expose productId parameter too
+          const getReviews = await getQuery('product-api_GET_{productId}_reviews');
+          expect(getReviews.markdown).toContain('- **productId** (path)');
+
+          // POST /{productId}/reviews — should have a request body schema file
+          const submitReview = await getCommand('product-api_POST_{productId}_reviews');
+          expect(submitReview.schemaPath).toEqual('request-body.json');
+          const requestBodyPath = join(
+            catalogDir,
+            'services',
+            'product-api',
+            'commands',
+            'product-api_POST_{productId}_reviews',
+            'request-body.json'
+          );
+          const requestBody = await fs.readFile(requestBodyPath, 'utf8');
+          expect(requestBody).toContain('productId');
+
+          // GET /{productId} 200 response should reference the Product schema (not the root GET array)
+          const productByIdResponsePath = join(
+            catalogDir,
+            'services',
+            'product-api',
+            'queries',
+            'product-api_GET_{productId}',
+            'response-200.json'
+          );
+          const productByIdResponse = await fs.readFile(productByIdResponsePath, 'utf8');
+          const parsed = JSON.parse(productByIdResponse);
+          // Single Product object, not an array — proves it's this operation's schema, not /'s
+          expect(parsed.type).toEqual('object');
+          expect(parsed.properties).toHaveProperty('id');
+        });
       });
 
       describe('config option: generateMarkdown', () => {

--- a/packages/generator-openapi/src/utils/messages.ts
+++ b/packages/generator-openapi/src/utils/messages.ts
@@ -170,7 +170,11 @@ export const buildMessage = async (
   serviceVersion?: string
 ) => {
   // Pass the document to avoid re-parsing (needed for authenticated URLs)
-  const requestBodiesAndResponses = await getSchemasByOperationId(pathToFile, operation.operationId, document as any);
+  // When operationId is missing, fall back to path+method so each operation gets its own schemas
+  const requestBodiesAndResponses = await getSchemasByOperationId(pathToFile, operation.operationId, document as any, {
+    path: operation.path,
+    method: operation.method,
+  });
   const extensions = operation.extensions || {};
 
   const operationTags = operation.tags.map((badge) => ({

--- a/packages/generator-openapi/src/utils/openapi.ts
+++ b/packages/generator-openapi/src/utils/openapi.ts
@@ -5,8 +5,9 @@ const DEFAULT_MESSAGE_TYPE = 'query';
 
 export async function getSchemasByOperationId(
   filePath: string,
-  operationId: string,
-  parsedDocument?: OpenAPIDocument
+  operationId: string | undefined,
+  parsedDocument?: OpenAPIDocument,
+  fallback?: { path: string; method: string }
 ): Promise<OpenAPIOperation | undefined> {
   try {
     // Use pre-parsed document if provided, otherwise parse from file
@@ -27,7 +28,14 @@ export async function getSchemasByOperationId(
         // Cast operation to OpenAPIOperation type
         const typedOperation = operation as OpenAPIOperation;
 
-        if (typedOperation.operationId === operationId) {
+        const matchesById = operationId !== undefined && typedOperation.operationId === operationId;
+        const matchesByPathAndMethod =
+          operationId === undefined &&
+          fallback !== undefined &&
+          path === fallback.path &&
+          method.toLowerCase() === fallback.method.toLowerCase();
+
+        if (matchesById || matchesByPathAndMethod) {
           // Extract query parameters
           if (typedOperation.parameters) {
             schemas.parameters = typedOperation.parameters;
@@ -60,7 +68,8 @@ export async function getSchemasByOperationId(
       }
     }
 
-    throw new Error(`Operation with ID "${operationId}" not found.`);
+    const identifier = operationId ?? (fallback ? `${fallback.method.toUpperCase()} ${fallback.path}` : 'unknown');
+    throw new Error(`Operation with ID "${identifier}" not found.`);
   } catch (error) {
     console.error('Error parsing OpenAPI file or finding operation:', error);
     return;


### PR DESCRIPTION
Closes #219

## What This PR Does

Fixes a bug where the OpenAPI generator failed to produce per-operation schemas, parameters, and request bodies when specs omitted `operationId`. Every operation missing an `operationId` ended up sharing the first such operation's schemas, leaving messages without their own parameter blocks, request body files, or response schemas.

## Changes Overview

### Key Changes

- `utils/openapi.ts`: `getSchemasByOperationId` now accepts an optional `{ path, method }` fallback and uses it when `operationId` is undefined instead of relying on `undefined === undefined` strict-equality matches
- `utils/messages.ts`: `buildMessage` passes the operation's path and method through so the fallback can resolve the correct operation
- `test/plugin.test.ts`: Adds a regression test against `without-operationIds.yml` asserting that each operation-id-less message gets its own parameters, request body file, and response schema

## How It Works

`getSchemasByOperationId` iterates every operation in the spec looking for a match. The prior match condition was `typedOperation.operationId === operationId`. Since JavaScript's `undefined === undefined` is `true`, the first operation in the spec that also lacked an `operationId` matched for every subsequent lookup, so all operation-id-less operations received the first operation's parameters/requestBody/responses.

The fix adds a second match path: when the caller did not pass an `operationId` (i.e. it's `undefined`) but did pass a `fallback` of `{ path, method }`, match by `path === fallback.path && method.toLowerCase() === fallback.method.toLowerCase()`. `buildMessage` now always passes the fallback so the lookup is unambiguous regardless of whether `operationId` is present.

## Breaking Changes

None. Existing specs with `operationId` continue to match by id; only the previously-broken path (missing `operationId`) changes behavior, and it now matches the documented expectation from the issue.

## Additional Notes

- `getExamplesByOperationId` has the same `undefined === undefined` shape, but it's already gated by `if (parseExamples && operation.operationId)` in `index.ts`, so examples are simply skipped for specs without operationIds rather than being wrong. Left as-is for this fix.
- Full openapi suite passes (155/155).