### PR TITLE
fix(generator-openapi): match consumer routes with leading wildcard

### DIFF
--- a/.changeset/leading-wildcard-route-match.md
+++ b/.changeset/leading-wildcard-route-match.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/generator-openapi': patch
+---
+
+Fix consumer route wildcard matching so patterns with a leading `*` (e.g. `*/adopted`) correctly match OpenAPI paths that start with `/`.

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -2989,6 +2989,32 @@ describe('OpenAPI EventCatalog Plugin', () => {
     });
 
     describe('route filtering - wildcard match', () => {
+      it('wildcard * at the start matches paths with leading segments', async () => {
+        const { getService } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [
+            {
+              path: join(openAPIExamples, 'petstore.yml'),
+              id: 'swagger-petstore',
+              consumers: [
+                {
+                  id: 'orders-service',
+                  version: '1.0.0',
+                  routes: [{ match: '*/adopted' }],
+                },
+              ],
+            },
+          ],
+        });
+
+        const consumer = await getService('orders-service', '1.0.0');
+
+        // */adopted should match /pets/{petId}/adopted
+        expect(consumer.sends).toHaveLength(1);
+        expect(consumer.sends).toEqual(expect.arrayContaining([expect.objectContaining({ id: 'petAdopted' })]));
+      });
+
       it('wildcard * matches any path segments', async () => {
         const { getService } = utils(catalogDir);
 

--- a/packages/generator-openapi/src/utils/consumers.ts
+++ b/packages/generator-openapi/src/utils/consumers.ts
@@ -13,10 +13,15 @@ type Pointer = {
 
 const toArray = (value: string | string[]): string[] => (Array.isArray(value) ? value : [value]);
 
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const matchesWildcard = (operationPath: string, pattern: string): boolean => {
-  // Convert wildcard pattern to regex: * matches one or more path segments
-  const regexStr = '^' + pattern.replace(/\*/g, '[^/]+(/[^/]+)*') + '$';
-  return new RegExp(regexStr).test(operationPath);
+  // Compare normalized paths so leading wildcards also match OpenAPI paths that start with /
+  const normalizedPath = operationPath.replace(/^\/+/, '');
+  const normalizedPattern = pattern.replace(/^\/+/, '');
+  const regexStr = '^' + normalizedPattern.split('*').map(escapeRegExp).join('[^/]+(?:/[^/]+)*') + '$';
+
+  return new RegExp(regexStr).test(normalizedPath);
 };
 
 const matchesSingleFilter = (operationPath: string, filter: RouteFilter): boolean => {


### PR DESCRIPTION
## What This PR Does

Fixes a bug in the OpenAPI generator where consumer route patterns starting with `*` (for example `*/adopted`) failed to match OpenAPI operation paths. OpenAPI operation paths always begin with a `/`, which the previous regex could not absorb before the wildcard, so these patterns silently matched nothing.

## Changes Overview

### Key Changes

- Normalize the leading `/` on both the operation path and the pattern before regex matching, so `*/adopted` now matches `/pets/{petId}/adopted`.
- Escape regex metacharacters in the literal portions of the pattern so path segments like `{petId}` are handled safely.
- Add a regression test for the leading-wildcard case in `plugin.test.ts`.

## How It Works

`matchesWildcard` now strips any leading slashes from both the operation path and the pattern, splits the pattern on `*`, escapes each literal chunk, and rejoins using `[^/]+(?:/[^/]+)*` to represent "one or more path segments". This keeps the original multi-segment wildcard semantics while allowing a wildcard to appear at the start of the pattern.

## Breaking Changes

None.

## Additional Notes

Existing wildcard tests continue to pass; only the previously-broken leading-wildcard scenario changes behavior.