### PR TITLE
fix(generator-openapi): group path-prefix when multiple verbs share a single path

### DIFF
--- a/.changeset/basket-paths-group-together.md
+++ b/.changeset/basket-paths-group-together.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(generator-openapi): group path-prefix when multiple verbs share a single path

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -63,21 +63,21 @@ const getPathPrefix = (path: string): string | undefined => {
 };
 
 /**
- * Build a set of path prefixes that appear across 2+ distinct paths.
- * Only prefixes shared by multiple paths are worth grouping — e.g. /orders
- * and /orders/{id} both share "orders", but /health is the only path with "health".
+ * Build a set of path prefixes shared by 2+ operations.
+ * Prefixes with only a single operation aren't worth grouping. Counts operations
+ * rather than distinct paths so that multiple verbs on the same path (e.g.
+ * GET/POST/PUT on /basket) still group together.
  */
 const buildGroupablePrefixes = (operations: Operation[]): Set<string> => {
-  const prefixToPaths = new Map<string, Set<string>>();
+  const prefixCounts = new Map<string, number>();
   for (const op of operations) {
     const prefix = getPathPrefix(op.path);
     if (!prefix) continue;
-    if (!prefixToPaths.has(prefix)) prefixToPaths.set(prefix, new Set());
-    prefixToPaths.get(prefix)!.add(op.path);
+    prefixCounts.set(prefix, (prefixCounts.get(prefix) ?? 0) + 1);
   }
   const groupable = new Set<string>();
-  for (const [prefix, paths] of prefixToPaths) {
-    if (paths.size >= 2) groupable.add(prefix);
+  for (const [prefix, count] of prefixCounts) {
+    if (count >= 2) groupable.add(prefix);
   }
   return groupable;
 };

--- a/packages/generator-openapi/src/test/openapi-files/petstore-with-groups.yml
+++ b/packages/generator-openapi/src/test/openapi-files/petstore-with-groups.yml
@@ -186,3 +186,24 @@ paths:
       responses:
         '200':
           description: Notification sent
+
+  # --- Single path with multiple verbs — should group by /basket even though no sibling path shares the prefix ---
+  /basket:
+    post:
+      summary: Create a basket
+      operationId: createBasket
+      responses:
+        '201':
+          description: Basket created
+    get:
+      summary: Show basket
+      operationId: showBasket
+      responses:
+        '200':
+          description: Basket shown
+    put:
+      summary: Update basket
+      operationId: updateBasket
+      responses:
+        '200':
+          description: Basket updated

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -3656,6 +3656,25 @@ describe('OpenAPI EventCatalog Plugin', () => {
         expect(getStatus).toBeDefined();
         expect(getStatus).not.toHaveProperty('group');
       });
+
+      it('POST/GET/PUT on the same /basket path all receive group "/basket" even though only one distinct path uses that prefix', async () => {
+        const { getService } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [{ path: join(openAPIExamples, 'petstore-with-groups.yml'), id: 'petstore-path' }],
+          groupMessagesBy: 'path-prefix',
+        });
+
+        const service = await getService('petstore-path', '1.0.0');
+
+        const createBasket = service.receives?.find((r: any) => r.id === 'createBasket');
+        const showBasket = service.receives?.find((r: any) => r.id === 'showBasket');
+        const updateBasket = service.receives?.find((r: any) => r.id === 'updateBasket');
+
+        expect(createBasket).toEqual(expect.objectContaining({ id: 'createBasket', group: '/basket' }));
+        expect(showBasket).toEqual(expect.objectContaining({ id: 'showBasket', group: '/basket' }));
+        expect(updateBasket).toEqual(expect.objectContaining({ id: 'updateBasket', group: '/basket' }));
+      });
     });
 
     it('no messages have a group property when groupMessagesBy is not configured', async () => {


### PR DESCRIPTION
## What This PR Does

Fixes a bug in the OpenAPI generator's `path-prefix` grouping. Previously, `buildGroupablePrefixes` counted *distinct paths* per prefix, so a single path like `/basket` with multiple operations (GET, POST, PUT) wasn't considered groupable — its operations were left ungrouped. Now operations per prefix are counted, so sibling verbs on the same path group together under that prefix.

## Changes Overview

### Key Changes

- `buildGroupablePrefixes` in `packages/generator-openapi/src/index.ts` now counts operations per prefix instead of distinct paths.
- Added `/basket` with POST/GET/PUT to the `petstore-with-groups.yml` fixture to cover the single-path/multi-verb case.
- Added a test asserting all three `/basket` operations receive `group: '/basket'`.

## How It Works

`getPathPrefix` extracts the first segment of a path (e.g. `/basket` from `/basket` or `/basket/{id}`). The old implementation kept a `Map<prefix, Set<path>>` and required `paths.size >= 2`, which excluded a lone path even if it had many operations. The new implementation keeps a `Map<prefix, number>` incrementing per operation, so three verbs on `/basket` yield a count of 3 and the prefix becomes groupable.

## Breaking Changes

None. Operations that were already grouped remain grouped; this only adds grouping for single-path multi-verb cases that were previously missed.

## Additional Notes

- Changeset: `patch` bump for `@eventcatalog/core`.