### PR TITLE
fix: correct changeset package name

### DIFF
--- a/.changeset/basket-paths-group-together.md
+++ b/.changeset/basket-paths-group-together.md
@@ -1,5 +1,5 @@
 ---
-'@eventcatalog/core': patch
+'@eventcatalog/generator-openapi': patch
 ---
 
 fix(generator-openapi): group path-prefix when multiple verbs share a single path


### PR DESCRIPTION
## What This PR Does

Fixes the release workflow failure on `main` caused by the changeset added in #394. The changeset targeted `@eventcatalog/core`, which doesn't exist in this workspace — this is the generators monorepo. Updates it to `@eventcatalog/generator-openapi` so `changeset version` can resolve the package.

## Related

- Release run: https://github.com/event-catalog/generators/actions/runs/24454630198
- Previous PR: #394

## Breaking Changes

None.