### PR TITLE
feat(generator-openapi): add single-group option to groupMessagesBy

### DIFF
--- a/.changeset/brave-otters-wander.md
+++ b/.changeset/brave-otters-wander.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/generator-openapi': patch
+---
+
+feat(generator-openapi): add `single-group` option to `groupMessagesBy` for large APIs

--- a/packages/generator-federation/src/test/plugin.test.ts
+++ b/packages/generator-federation/src/test/plugin.test.ts
@@ -61,7 +61,7 @@ describe('generator-federation', () => {
       });
 
       const services = await fs.readdir(path.join(catalogDir, 'services'));
-      expect(services).toHaveLength(8);
+      expect(services).toHaveLength(9);
     },
     { timeout: 20000 }
   );

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -41,8 +41,11 @@ type Props = {
    * - `'x-extension'`: Use the `x-eventcatalog-group` extension on each operation.
    * - `'path-prefix'`: Derive the group from the first meaningful URL path segment
    *    (skips common prefixes like `api`, `v1`, `v2`).
+   * - `'single-group'`: Put every operation into one group (labelled `operations`).
+   *    Useful for large APIs where the visualiser would otherwise render hundreds
+   *    of top-level nodes.
    */
-  groupMessagesBy?: 'x-extension' | 'path-prefix';
+  groupMessagesBy?: 'x-extension' | 'path-prefix' | 'single-group';
 };
 
 const toUniqueArray = (array: Pointer[]) => {
@@ -96,6 +99,10 @@ const getMessageGroup = (
 
   if (groupMessagesBy === 'x-extension') {
     return operation.extensions?.['x-eventcatalog-group'] || undefined;
+  }
+
+  if (groupMessagesBy === 'single-group') {
+    return 'operations';
   }
 
   if (groupMessagesBy === 'path-prefix') {

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -3677,6 +3677,39 @@ describe('OpenAPI EventCatalog Plugin', () => {
       });
     });
 
+    describe('single-group', () => {
+      it('every message gets the single group labelled "operations"', async () => {
+        const { getService } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [{ path: join(openAPIExamples, 'petstore-with-groups.yml'), id: 'petstore-single-group' }],
+          groupMessagesBy: 'single-group',
+        });
+
+        const service = await getService('petstore-single-group', '1.0.0');
+        const allMessages = [...(service.receives || []), ...(service.sends || [])];
+
+        expect(allMessages.length).toBeGreaterThan(0);
+        for (const msg of allMessages) {
+          expect(msg).toEqual(expect.objectContaining({ group: 'operations' }));
+        }
+      });
+
+      it('getStatus (GET /status) receives group "operations" even though path-prefix would not group it', async () => {
+        const { getService } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [{ path: join(openAPIExamples, 'petstore-with-groups.yml'), id: 'petstore-single-group-lone' }],
+          groupMessagesBy: 'single-group',
+        });
+
+        const service = await getService('petstore-single-group-lone', '1.0.0');
+        const getStatus = service.receives?.find((r: any) => r.id === 'getStatus');
+
+        expect(getStatus).toEqual(expect.objectContaining({ id: 'getStatus', group: 'operations' }));
+      });
+    });
+
     it('no messages have a group property when groupMessagesBy is not configured', async () => {
       const { getService } = utils(catalogDir);
 


### PR DESCRIPTION
## What This PR Does

Adds a third value, `'single-group'`, to the OpenAPI generator's `groupMessagesBy` option. When set, every operation in the spec is assigned the same group label (`operations`). This gives users of very large OpenAPI specs (hundreds of routes) a way to collapse the EventCatalog visualiser down to a single top-level node, which is impractical to achieve with `'path-prefix'` (which only groups prefixes shared by 2+ operations and leaves lone paths ungrouped).

## Changes Overview

### Key Changes

- `packages/generator-openapi/src/index.ts` — extend the `groupMessagesBy` union type with `'single-group'` and handle it in `getMessageGroup` by returning the literal label `'operations'`.
- `packages/generator-openapi/src/test/plugin.test.ts` — new `describe('single-group')` block with two tests: every message receives `group: 'operations'`, and singleton-path operations (which `path-prefix` skips) are now grouped.

## How It Works

`getMessageGroup` branches on the `groupMessagesBy` value. For `'single-group'`, it short-circuits before any path analysis and returns `'operations'` unconditionally. No `buildGroupablePrefixes` pass is needed — grouping is 1:1 regardless of the spec shape. The option name (`single-group`) describes the mechanism, the label (`operations`) describes what the user sees in the visualiser.

## Breaking Changes

None. Additive change — existing `'x-extension'` and `'path-prefix'` behaviour is unchanged.

## Additional Notes

- Follow-up: update the generator-openapi docs on the website to describe the new value.