### PR TITLE
feat(generator-openapi): warn when spec has 50+ operations

### DIFF
--- a/.changeset/wise-hedgehogs-murmur.md
+++ b/.changeset/wise-hedgehogs-murmur.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/generator-openapi': patch
+---
+
+feat(generator-openapi): warn when a spec has 50+ operations without `groupMessagesBy` set

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -52,6 +52,9 @@ const toUniqueArray = (array: Pointer[]) => {
   return array.filter((item, index, self) => index === self.findIndex((t) => t.id === item.id && t.version === item.version));
 };
 
+// Warn the user when a spec is large enough that the visualiser becomes hard to read without grouping.
+const LARGE_SPEC_OPERATION_THRESHOLD = 50;
+
 // Matches common API versioning segments like "api", "v1", "v2", "v10", etc.
 const isSkippableSegment = (segment: string): boolean => /^(api|v\d+)$/i.test(segment);
 
@@ -546,6 +549,12 @@ const processMessagesForOpenAPISpec = async (
 
   // Pre-build the set of path prefixes shared by 2+ distinct paths (for path-prefix grouping)
   const groupablePrefixes = options.groupMessagesBy === 'path-prefix' ? buildGroupablePrefixes(operations) : undefined;
+
+  if (!options.groupMessagesBy && operations.length >= LARGE_SPEC_OPERATION_THRESHOLD) {
+    console.warn(
+      `[generator-openapi] This spec has ${operations.length} operations. The EventCatalog visualiser may be hard to read — consider setting groupMessagesBy: 'path-prefix' or 'single-group' to group them. See https://www.eventcatalog.dev/docs/plugins/openapi/features#group-messages`
+    );
+  }
 
   let receives = [],
     sends = [];

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -3710,6 +3710,69 @@ describe('OpenAPI EventCatalog Plugin', () => {
       });
     });
 
+    describe('large-spec warning', () => {
+      const buildLargeSpec = async (operationCount: number): Promise<string> => {
+        const paths: Record<string, any> = {};
+        for (let i = 0; i < operationCount; i++) {
+          paths[`/thing-${i}`] = {
+            get: {
+              summary: `get thing ${i}`,
+              operationId: `getThing${i}`,
+              responses: { '200': { description: 'ok' } },
+            },
+          };
+        }
+        const spec = {
+          openapi: '3.0.0',
+          info: { title: 'Large', version: '1.0.0' },
+          paths,
+        };
+        const specPath = join(catalogDir, 'large-spec.json');
+        await fs.writeFile(specPath, JSON.stringify(spec));
+        return specPath;
+      };
+
+      it('warns when the spec has 50+ operations and groupMessagesBy is not set', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const specPath = await buildLargeSpec(50);
+
+        await plugin(config, {
+          services: [{ path: specPath, id: 'large-no-group' }],
+        });
+
+        const warned = warn.mock.calls.some((args) => String(args[0]).includes('50 operations'));
+        expect(warned).toBe(true);
+        warn.mockRestore();
+      });
+
+      it('does not warn when groupMessagesBy is set, even for large specs', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const specPath = await buildLargeSpec(50);
+
+        await plugin(config, {
+          services: [{ path: specPath, id: 'large-with-group' }],
+          groupMessagesBy: 'single-group',
+        });
+
+        const warned = warn.mock.calls.some((args) => String(args[0]).includes('operations'));
+        expect(warned).toBe(false);
+        warn.mockRestore();
+      });
+
+      it('does not warn for specs under the threshold', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const specPath = await buildLargeSpec(10);
+
+        await plugin(config, {
+          services: [{ path: specPath, id: 'small-no-group' }],
+        });
+
+        const warned = warn.mock.calls.some((args) => String(args[0]).includes('operations'));
+        expect(warned).toBe(false);
+        warn.mockRestore();
+      });
+    });
+
     it('no messages have a group property when groupMessagesBy is not configured', async () => {
       const { getService } = utils(catalogDir);
 


### PR DESCRIPTION
## What This PR Does

Adds a console warning emitted during generation when an OpenAPI spec has 50 or more operations and `groupMessagesBy` is not configured. At that size the EventCatalog visualiser becomes hard to read, so the warning points users at the two grouping options plus the docs page that explains them.

## Related

- Depends on #397 (introduces the `'single-group'` option referenced by the warning message). Merge #397 first.

## Changes Overview

### Key Changes

- `packages/generator-openapi/src/index.ts` — new `LARGE_SPEC_OPERATION_THRESHOLD = 50` constant; emit a `console.warn` in the main generation loop when `operations.length >= 50` and no `groupMessagesBy` is set.
- `packages/generator-openapi/src/test/plugin.test.ts` — new `describe('large-spec warning')` block with three tests: warns at the threshold, does not warn when `groupMessagesBy` is set, does not warn below the threshold. Uses a generated JSON fixture to avoid hand-authoring 50 operations.

## How It Works

Right after operations are collected, the generator checks whether grouping is configured. If not, and operation count meets or exceeds the threshold, it prints:

> `[generator-openapi] This spec has N operations. The EventCatalog visualiser may be hard to read — consider setting groupMessagesBy: 'path-prefix' or 'single-group' to group them. See https://www.eventcatalog.dev/docs/plugins/openapi/features#group-messages`

No behaviour change beyond the warning — generation continues as before.

## Breaking Changes

None.

## Additional Notes

- 50 is a deliberate pick — above this, per-route sidebar nodes are typically impractical.
- Intentionally a warning, not an auto-override, so user config stays authoritative.