### PR TITLE
fix(generators): preserve existing service location when re-running without domain config

### DIFF
--- a/.changeset/preserve-existing-service-domain-path.md
+++ b/.changeset/preserve-existing-service-domain-path.md
@@ -1,0 +1,6 @@
+---
+'@eventcatalog/generator-openapi': patch
+'@eventcatalog/generator-asyncapi': patch
+---
+
+fix: preserve existing service location when re-running the generator without a `domain` configured. Previously, if a service already existed inside a domain (e.g. `domains/orders/services/my-service`) and the generator was re-run without the `domain` option set, the generator would write a duplicate copy of the service to the catalog root at `services/my-service`. The generators now resolve the existing service's on-disk location via `getResourcePath` and write back in-place, matching the behaviour already used for consumer services.

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -397,6 +397,20 @@ export default async (config: any, options: Props) => {
       } else {
         servicePath = path.join('../', 'domains', options.domain.id, 'services', service.id);
       }
+    } else {
+      // No domain configured, but the service may already exist somewhere in the catalog
+      // (e.g. inside a domain). Write back in-place so we don't duplicate it at /services.
+      const existingService = await getService(serviceId, 'latest');
+      if (existingService) {
+        const existingServiceResource = await getResourcePath(
+          process.env.PROJECT_DIR as string,
+          serviceId,
+          existingService.version
+        );
+        if (existingServiceResource) {
+          servicePath = path.join('../', existingServiceResource.directory);
+        }
+      }
     }
     if (options.writeFilesToRoot) {
       servicePath = service.id;

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -275,6 +275,43 @@ describe('AsyncAPI EventCatalog Plugin', () => {
       );
     });
 
+    it('when the AsyncAPI service already exists inside a domain and no domain is configured on the generator, the service stays in that domain and is not duplicated at the catalog root', async () => {
+      const { writeDomain, addServiceToDomain, writeService, getService } = utils(catalogDir);
+
+      await writeDomain({
+        id: 'orders',
+        name: 'Orders Domain',
+        version: '1.0.0',
+        markdown: '',
+      });
+
+      await writeService(
+        {
+          id: 'account-service',
+          version: '1.0.0',
+          name: 'Account Service',
+          markdown: '# Existing',
+        },
+        { path: join('../', 'domains', 'orders', 'services', 'account-service') }
+      );
+
+      await addServiceToDomain('orders', { id: 'account-service', version: '1.0.0' }, '1.0.0');
+
+      await plugin(config, {
+        services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service' }],
+      });
+
+      const service = await getService('account-service', '1.0.0');
+      expect(service).toBeDefined();
+
+      // Service should still live inside the orders domain on disk, not duplicated at /services
+      const serviceInDomain = existsSync(join(catalogDir, 'domains', 'orders', 'services', 'account-service', 'index.mdx'));
+      expect(serviceInDomain).toBe(true);
+
+      const serviceAtRoot = existsSync(join(catalogDir, 'services', 'account-service', 'index.mdx'));
+      expect(serviceAtRoot).toBe(false);
+    });
+
     it('when the AsyncAPI service is already defined in EventCatalog and the versions match, only metadata is updated', async () => {
       // Create a service with the same name and version as the AsyncAPI file for testing
       const { writeService, getService } = utils(catalogDir);

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -287,6 +287,11 @@ export default async (_: any, options: Props) => {
         await addServiceToDomain(domainId, { id: service.id, version: service.version }, domainVersion);
       }
 
+      // Check if service is already defined... if the versions do not match then create service.
+      const latestServiceInCatalog = await getService(service.id, 'latest');
+      const versionTheService = latestServiceInCatalog && isVersionGreaterThan(version, latestServiceInCatalog.version);
+      console.log(chalk.blue(`Processing service: ${document.info.title} (v${version})`));
+
       // Have to ../ as the SDK will put the files into hard coded folders
       // Use getResourcePath to resolve the actual domain location (supports subdomains)
       let servicePath = join('../', 'services', service.id);
@@ -301,15 +306,21 @@ export default async (_: any, options: Props) => {
         } else {
           servicePath = join('../', 'domains', options.domain.id, 'services', service.id);
         }
+      } else if (latestServiceInCatalog) {
+        // No domain configured, but the service already exists somewhere in the catalog
+        // (e.g. inside a domain). Write back in-place so we don't duplicate it at /services.
+        const existingServiceResource = await getResourcePath(
+          process.env.PROJECT_DIR as string,
+          service.id,
+          latestServiceInCatalog.version
+        );
+        if (existingServiceResource) {
+          servicePath = join('../', existingServiceResource.directory);
+        }
       }
       if (options.writeFilesToRoot) {
         servicePath = service.id;
       }
-
-      // Check if service is already defined... if the versions do not match then create service.
-      const latestServiceInCatalog = await getService(service.id, 'latest');
-      const versionTheService = latestServiceInCatalog && isVersionGreaterThan(version, latestServiceInCatalog.version);
-      console.log(chalk.blue(`Processing service: ${document.info.title} (v${version})`));
 
       // If the version is less than the latest service version, we need to write is a versioned service
       if (latestServiceInCatalog && isVersionLessThan(version, latestServiceInCatalog.version)) {

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -387,6 +387,43 @@ describe('OpenAPI EventCatalog Plugin', () => {
         expect(service.sends).toHaveLength(2);
       });
 
+      it('when the OpenAPI service already exists inside a domain and no domain is configured on the generator, the service stays in that domain and is not duplicated at the catalog root', async () => {
+        const { writeDomain, addServiceToDomain, writeService, getService } = utils(catalogDir);
+
+        await writeDomain({
+          id: 'orders',
+          name: 'Orders Domain',
+          version: '1.0.0',
+          markdown: '',
+        });
+
+        await writeService(
+          {
+            id: 'swagger-petstore',
+            version: '1.0.0',
+            name: 'Swagger Petstore',
+            markdown: '# Existing',
+          },
+          { path: join('../', 'domains', 'orders', 'services', 'swagger-petstore') }
+        );
+
+        await addServiceToDomain('orders', { id: 'swagger-petstore', version: '1.0.0' }, '1.0.0');
+
+        await plugin(config, {
+          services: [{ path: join(openAPIExamples, 'petstore.yml'), id: 'swagger-petstore' }],
+        });
+
+        const service = await getService('swagger-petstore', '1.0.0');
+        expect(service).toBeDefined();
+
+        // Service should still live inside the orders domain on disk, not duplicated at /services
+        const serviceInDomain = existsSync(join(catalogDir, 'domains', 'orders', 'services', 'swagger-petstore', 'index.mdx'));
+        expect(serviceInDomain).toBe(true);
+
+        const serviceAtRoot = existsSync(join(catalogDir, 'services', 'swagger-petstore', 'index.mdx'));
+        expect(serviceAtRoot).toBe(false);
+      });
+
       it('when the OpenAPI service is already defined in EventCatalog and the processed specification version is greater than the existing service version, a new service is created and the old one is versioned', async () => {
         // Create a service with the same name and version as the OpenAPI file for testing
         const { writeService, getService } = utils(catalogDir);


### PR DESCRIPTION
## What This PR Does

Fixes a bug in the OpenAPI and AsyncAPI generators where re-running the generator against a service that already exists inside a domain (e.g. `domains/orders/services/my-service`) would create a duplicate copy of the service at the catalog root (`services/my-service`) if the generator config did not set a `domain` option.

The generators now look up the existing service's on-disk location via `getResourcePath` and write back in-place, mirroring the behaviour already used for consumer services.

## Changes Overview

### Key Changes

- `packages/generator-openapi/src/index.ts`: moved the `getService(id, 'latest')` lookup before `servicePath` is computed. When no `domain` is configured on the generator but the service already exists in the catalog, resolve its existing directory via `getResourcePath` and use that as the write path.
- `packages/generator-asyncapi/src/index.ts`: same fix, applied in the `servicePath` computation branch.
- Added a regression test in each generator's `plugin.test.ts` that pre-seeds a service inside a domain, runs the generator without `options.domain`, and asserts the service stays in the domain and no duplicate appears at `/services/<id>`.

## How It Works

Both generators compute `servicePath` before calling `writeService`. The previous logic defaulted to `../services/<id>` and only overrode it when `options.domain` was set. Consumers in the same file already had a matching in-place resolution path — the main service branch did not.

The fix adds an `else` branch: if `options.domain` is not configured but `getService(id, 'latest')` returns an existing service, call `getResourcePath(PROJECT_DIR, id, version)` to find its current directory on disk and set `servicePath` to `join('../', resource.directory)`. When `writeService` runs with `override: true`, it now updates the existing file instead of creating a duplicate at the root.

## Breaking Changes

None. This only changes behaviour for users who were hitting the bug; for all other cases the write path is unchanged.

## Additional Notes

- The other generator packages (`generator-github`, `generator-graphql`, `generator-eventbridge`, `generator-aws-glue`, `generator-apicurio`, `generator-confluent-schema-registry`, `generator-azure-schema-registry`) all share the same `join('../', 'services', service.id)` default and likely have the same bug. Not addressed in this PR — to be followed up separately.
- Full test suites pass for both generators (167 OpenAPI tests, 134 AsyncAPI tests).