### PR TITLE
fix(generators): do not demote newer cataloged messages when regenerating against older specs

### DIFF
--- a/.changeset/semver-aware-message-versioning.md
+++ b/.changeset/semver-aware-message-versioning.md
@@ -1,0 +1,7 @@
+---
+'@eventcatalog/generator-eventbridge': patch
+'@eventcatalog/generator-asyncapi': patch
+'@eventcatalog/generator-openapi': patch
+---
+
+fix: stop demoting newer cataloged messages when the generator is re-run against an older spec. The EventBridge, AsyncAPI and OpenAPI generators previously used a plain `!==` version check before calling `versionEvent` / `versionMessage`, which meant any version difference would move the cataloged entry into `versioned/` and write the incoming one at the root — even when the incoming version was older. The generators now use a semver-aware comparison (with `semver.coerce` so non-semver versions like EventBridge's integer counters still sort numerically) and only demote the cataloged entry when the incoming version is strictly newer. When the incoming version is older or cannot be confidently compared, the generator logs a warning, leaves the cataloged entry untouched, and points the service's `sends`/`receives` at the existing cataloged version.

--- a/packages/generator-asyncapi/package.json
+++ b/packages/generator-asyncapi/package.json
@@ -23,6 +23,7 @@
     "@types/lodash": "^4.17.7",
     "@types/minimist": "^1.2.5",
     "@types/node": "^20.16.1",
+    "@types/semver": "^7.7.0",
     "prettier": "^3.3.3",
     "tsup": "^8.1.0",
     "typescript": "^5.5.3",
@@ -46,6 +47,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.23",
     "minimist": "^1.2.8",
+    "semver": "^7.7.2",
     "slugify": "^1.6.6",
     "update-notifier": "^7.3.1",
     "zod": "^3.23.8"

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -22,6 +22,7 @@ import {
 import { defaultMarkdown as generateMarkdownForService, getSummary as getServiceSummary } from './utils/services';
 import { defaultMarkdown as generateMarkdownForDomain } from './utils/domains';
 import { defaultMarkdown as generateMarkdownForChannel, getChannelProtocols, getChannelTags } from './utils/channels';
+import { isNewerVersion, isSameVersion } from './utils/versions';
 import checkLicense from '../../../shared/checkLicense';
 
 import { EventType, MessageOperations } from './types';
@@ -478,7 +479,7 @@ export default async (config: any, options: Props) => {
     for (const operation of operations) {
       for (const message of operation.messages()) {
         const eventType = (message.extensions().get('x-eventcatalog-message-type')?.value() as EventType) || 'event';
-        const messageVersion = message.extensions().get('x-eventcatalog-message-version')?.value() || version;
+        let messageVersion = message.extensions().get('x-eventcatalog-message-version')?.value() || version;
         const deprecatedDate = message.extensions().get('x-eventcatalog-deprecated-date')?.value() || null;
         const deprecatedMessage = message.extensions().get('x-eventcatalog-deprecated-message')?.value() || null;
         const isMessageMarkedAsDraft =
@@ -532,6 +533,7 @@ export default async (config: any, options: Props) => {
         if (serviceOwnsMessageContract) {
           // Check if the message already exists in the catalog
           const catalogedMessage = await getMessage(messageId, 'latest');
+          let shouldWriteMessage = true;
 
           if (catalogedMessage) {
             // persist markdown, badges and attachments if it exists
@@ -539,72 +541,88 @@ export default async (config: any, options: Props) => {
             messageBadges = catalogedMessage.badges || null;
             messageAttachments = catalogedMessage.attachments || null;
 
-            if (catalogedMessage.version !== messageVersion) {
-              // if the version does not match, we need to version the message
+            const catalogedVersion = catalogedMessage.version ?? '';
+
+            if (isSameVersion(catalogedVersion, messageVersion)) {
+              // Same version - continue and overwrite the message in place
+            } else if (isNewerVersion(messageVersion, catalogedVersion)) {
+              // Incoming is strictly newer - version the cataloged one and write the new one at root
               await versionMessage(messageId);
               console.log(chalk.cyan(` - Versioned previous message: (v${catalogedMessage.version})`));
+            } else {
+              // Incoming is older than (or not confidently newer than) the cataloged version.
+              // Leave the cataloged entry alone and point the service's sends/receives at it.
+              console.log(
+                chalk.yellow(
+                  ` - Skipping ${messageId} (v${messageVersion}) - catalog already has a newer version (v${catalogedVersion})`
+                )
+              );
+              messageVersion = catalogedVersion;
+              shouldWriteMessage = false;
             }
           }
 
-          await writeMessage(
-            {
-              id: messageId,
-              version: messageVersion,
-              name: getMessageName(message),
-              summary: getMessageSummary(message),
-              markdown: messageMarkdown,
-              badges:
-                messageBadges || badges.map((badge) => ({ content: badge.name(), textColor: 'blue', backgroundColor: 'blue' })),
-              ...(messageHasSchema(message) && { schemaPath: getSchemaFileName(message) }),
-              ...(owners && { owners }),
-              ...(messageAttachments && { attachments: messageAttachments }),
-              ...(deprecatedDate && {
-                deprecated: { date: deprecatedDate, ...(deprecatedMessage && { message: deprecatedMessage }) },
-              }),
-              ...(isMessageMarkedAsDraft && { draft: true }),
-            },
-            {
-              override: true,
-              path: messagePath,
-            }
-          );
-
-          console.log(chalk.cyan(` - Message (v${messageVersion}) created`));
-
-          // Check if the message has a payload, if it does then document in EventCatalog
-          if (messageHasSchema(message)) {
-            const schema = getSchemaForMessage(message, attachHeadersToSchema);
-
-            // Normalize path separators and remove leading relative path segments (../ or ./ for both Unix and Windows)
-            const cleanedMessagePath = messagePath
-              .replace(/\\/g, '/') // Convert all backslashes to forward slashes
-              .replace(/^(\.\.\/|\.\/)+/g, ''); // Remove all leading ../ or ./ segments
-
-            await addSchemaToMessage(
-              messageId,
+          if (shouldWriteMessage) {
+            await writeMessage(
               {
-                fileName: getSchemaFileName(message),
-                schema: safeStringify(schema, 4),
+                id: messageId,
+                version: messageVersion,
+                name: getMessageName(message),
+                summary: getMessageSummary(message),
+                markdown: messageMarkdown,
+                badges:
+                  messageBadges || badges.map((badge) => ({ content: badge.name(), textColor: 'blue', backgroundColor: 'blue' })),
+                ...(messageHasSchema(message) && { schemaPath: getSchemaFileName(message) }),
+                ...(owners && { owners }),
+                ...(messageAttachments && { attachments: messageAttachments }),
+                ...(deprecatedDate && {
+                  deprecated: { date: deprecatedDate, ...(deprecatedMessage && { message: deprecatedMessage }) },
+                }),
+                ...(isMessageMarkedAsDraft && { draft: true }),
               },
-              messageVersion,
-              { path: cleanedMessagePath }
-            );
-            console.log(chalk.cyan(` - Schema added to message (v${messageVersion})`));
-          }
-
-          // Add examples to the message if parseExamples is enabled
-          if (parseExamples) {
-            const messageExamples = message.examples().all();
-            for (let i = 0; i < messageExamples.length; i++) {
-              const example = messageExamples[i];
-              const payload = example.payload();
-              if (payload) {
-                const fileName = example.hasName() ? `${example.name()}.json` : `example-${i}.json`;
-                await addExampleToMessage(messageId, { content: JSON.stringify(payload, null, 2), fileName }, messageVersion);
+              {
+                override: true,
+                path: messagePath,
               }
+            );
+
+            console.log(chalk.cyan(` - Message (v${messageVersion}) created`));
+
+            // Check if the message has a payload, if it does then document in EventCatalog
+            if (messageHasSchema(message)) {
+              const schema = getSchemaForMessage(message, attachHeadersToSchema);
+
+              // Normalize path separators and remove leading relative path segments (../ or ./ for both Unix and Windows)
+              const cleanedMessagePath = messagePath
+                .replace(/\\/g, '/') // Convert all backslashes to forward slashes
+                .replace(/^(\.\.\/|\.\/)+/g, ''); // Remove all leading ../ or ./ segments
+
+              await addSchemaToMessage(
+                messageId,
+                {
+                  fileName: getSchemaFileName(message),
+                  schema: safeStringify(schema, 4),
+                },
+                messageVersion,
+                { path: cleanedMessagePath }
+              );
+              console.log(chalk.cyan(` - Schema added to message (v${messageVersion})`));
             }
-            if (messageExamples.length > 0) {
-              console.log(chalk.cyan(` - ${messageExamples.length} example(s) added to message (v${messageVersion})`));
+
+            // Add examples to the message if parseExamples is enabled
+            if (parseExamples) {
+              const messageExamples = message.examples().all();
+              for (let i = 0; i < messageExamples.length; i++) {
+                const example = messageExamples[i];
+                const payload = example.payload();
+                if (payload) {
+                  const fileName = example.hasName() ? `${example.name()}.json` : `example-${i}.json`;
+                  await addExampleToMessage(messageId, { content: JSON.stringify(payload, null, 2), fileName }, messageVersion);
+                }
+              }
+              if (messageExamples.length > 0) {
+                console.log(chalk.cyan(` - ${messageExamples.length} example(s) added to message (v${messageVersion})`));
+              }
             }
           }
         } else {

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -1378,6 +1378,28 @@ describe('AsyncAPI EventCatalog Plugin', () => {
       expect(newEvent).toBeDefined();
     });
 
+    it('when the incoming message version is older than the cataloged one, the newer cataloged message is not demoted', async () => {
+      // The AsyncAPI spec for this service is version 1.0.0, so the UserSignedUp message
+      // is generated at v1.0.0. The catalog already has v2.0.0 (e.g. from a previous run
+      // against a newer spec). Regenerating from the older spec must NOT demote v2.0.0
+      // into `versioned/` and replace it with v1.0.0.
+      const { writeEvent, getEvent } = utils(catalogDir);
+
+      await writeEvent({
+        id: 'UserSignedUp',
+        version: '2.0.0',
+        name: 'UserSignedUp',
+        markdown: 'cataloged at v2.0.0',
+      });
+
+      await plugin(config, { services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service' }] });
+
+      const latest = await getEvent('UserSignedUp', 'latest');
+      expect(latest).toBeDefined();
+      expect(latest.version).toEqual('2.0.0');
+      expect(latest.markdown).toEqual('cataloged at v2.0.0');
+    });
+
     it('when a message already exists in EventCatalog the markdown, badges and attachments are persisted and not overwritten', async () => {
       const { writeEvent, getEvent } = utils(catalogDir);
 

--- a/packages/generator-asyncapi/src/utils/versions.ts
+++ b/packages/generator-asyncapi/src/utils/versions.ts
@@ -1,14 +1,4 @@
-import { satisfies, valid as semverValid, gt as semverGt, eq as semverEq, coerce as semverCoerce } from 'semver';
-
-// version is greater than or equal to the given version
-export const isVersionGreaterThan = (version: string, givenVersion: string) => {
-  return satisfies(version, `>${givenVersion}`);
-};
-
-// version is less than or equal to the given version
-export const isVersionLessThan = (version: string, givenVersion: string) => {
-  return satisfies(version, `<${givenVersion}`);
-};
+import { valid as semverValid, gt as semverGt, eq as semverEq, coerce as semverCoerce } from 'semver';
 
 const tryCoerceToSemver = (version: string): string | null => {
   if (semverValid(version)) return version;

--- a/packages/generator-eventbridge/package.json
+++ b/packages/generator-eventbridge/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@smithy/types": "^3.5.0",
     "@types/node": "^20.16.1",
+    "@types/semver": "^7.7.0",
     "prettier": "^3.3.3",
     "tsup": "^8.1.0",
     "typescript": "^5.5.3",
@@ -38,6 +39,7 @@
     "@changesets/cli": "^2.27.8",
     "@eventcatalog/sdk": "^2.18.2",
     "chalk": "4.1.2",
+    "semver": "^7.7.2",
     "update-notifier": "^7.3.1"
   },
   "repository": {

--- a/packages/generator-eventbridge/src/index.ts
+++ b/packages/generator-eventbridge/src/index.ts
@@ -22,6 +22,7 @@ import path, { join } from 'node:path';
 import fs from 'node:fs/promises';
 import pkgJSON from '../package.json';
 import { checkForPackageUpdate } from '../../../shared/check-for-package-update';
+import { isNewerVersion, isSameVersion } from './utils/versions';
 
 async function tryFetchJSONSchema(
   schemasClient: SchemasClient,
@@ -371,13 +372,24 @@ const processEvents = async (events: Event[], options: GeneratorProps, servicePa
       messageBadges = catalogedEvent.badges || messageBadges;
       messageAttachments = catalogedEvent.attachments;
       messageSummary = catalogedEvent.summary;
-      // if the version matches, we can override the message but keep markdown as it  was
-      if (catalogedEvent.version === event.version) {
+
+      const incomingVersion = event.version ?? '';
+      const cataloged = catalogedEvent.version ?? '';
+
+      if (isSameVersion(cataloged, incomingVersion)) {
+        // Same version - override the message but keep markdown as it was
         await rmEventById(event.id, event.version);
-      } else {
-        // if the version does not match, we need to version the message
+      } else if (isNewerVersion(incomingVersion, cataloged)) {
+        // Incoming is strictly newer - version the cataloged one and write the new one at root
         await versionEvent(event.id);
         console.log(chalk.cyan(` - Versioned previous message: (v${catalogedEvent.version})`));
+      } else {
+        // Incoming is older than (or not confidently newer than) the cataloged version.
+        // Skip to avoid demoting the newer cataloged entry.
+        console.log(
+          chalk.yellow(` - Skipping ${event.id} (v${incomingVersion}) - catalog already has a newer version (v${cataloged})`)
+        );
+        continue;
       }
     }
 

--- a/packages/generator-eventbridge/src/test/plugin.test.ts
+++ b/packages/generator-eventbridge/src/test/plugin.test.ts
@@ -1614,5 +1614,40 @@ describe('EventBridge EventCatalog Plugin', () => {
         );
       });
     });
+
+    describe('version ordering', () => {
+      it('does not demote a newer cataloged event when the incoming version is older', async () => {
+        // Reproduces https://discord/... user report: EventBridge schema has VersionCount=10 (older)
+        // but the catalog already has OrderPlaced v100 from a previous run. The generator must not
+        // move v100 into `versioned/` and replace it with v10. Older versions should never demote newer.
+        const { writeEvent, getEvent } = utils(catalogDir);
+
+        await writeEvent({
+          id: 'OrderPlaced',
+          version: '100',
+          name: 'OrderPlaced',
+          markdown: 'cataloged at v100',
+        });
+
+        await plugin(config, {
+          region: 'us-east-1',
+          registryName: 'discovered-schemas',
+          services: [
+            {
+              id: 'Orders Service',
+              version: '1.0.0',
+              sends: [{ source: ['myapp.orders'] }],
+            },
+          ],
+        });
+
+        const latest = await getEvent('OrderPlaced', 'latest');
+        expect(latest).toBeDefined();
+        expect(latest.version).toEqual('100');
+
+        const versionedV100 = await getEvent('OrderPlaced', '100');
+        expect(versionedV100.markdown).toEqual('cataloged at v100');
+      });
+    });
   });
 });

--- a/packages/generator-eventbridge/src/utils/versions.ts
+++ b/packages/generator-eventbridge/src/utils/versions.ts
@@ -1,14 +1,4 @@
-import { satisfies, valid as semverValid, gt as semverGt, eq as semverEq, coerce as semverCoerce } from 'semver';
-
-// version is greater than or equal to the given version
-export const isVersionGreaterThan = (version: string, givenVersion: string) => {
-  return satisfies(version, `>${givenVersion}`);
-};
-
-// version is less than or equal to the given version
-export const isVersionLessThan = (version: string, givenVersion: string) => {
-  return satisfies(version, `<${givenVersion}`);
-};
+import { valid as semverValid, gt as semverGt, eq as semverEq, coerce as semverCoerce } from 'semver';
 
 const tryCoerceToSemver = (version: string): string | null => {
   if (semverValid(version)) return version;
@@ -19,11 +9,11 @@ const tryCoerceToSemver = (version: string): string | null => {
 /**
  * Returns true when `incoming` is strictly newer than `existing`.
  *
- * Uses semver for comparison. Versions that aren't valid semver (e.g. integer
- * counters like "99", "100") are coerced via `semver.coerce` — "99" becomes
- * "99.0.0" — so they sort numerically as expected. When neither side can be
- * coerced we return `false`, so callers treat unknown versions as "not
- * confidently newer" and avoid demoting the cataloged entry.
+ * Uses semver for comparison. Versions that aren't valid semver (e.g. EventBridge's
+ * integer counters like "99", "100") are coerced via `semver.coerce` — "99" becomes
+ * "99.0.0" — so they sort numerically as expected. When neither side can be coerced
+ * we return `false`, so callers treat unknown versions as "not confidently newer"
+ * and avoid demoting the cataloged entry.
  */
 export const isNewerVersion = (incoming: string, existing: string): boolean => {
   if (!incoming || !existing) return false;

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -16,7 +16,7 @@ import yaml from 'js-yaml';
 import { join } from 'node:path';
 import pkgJSON from '../package.json';
 import { checkForPackageUpdate } from '../../../shared/check-for-package-update';
-import { isVersionGreaterThan, isVersionLessThan } from './utils/versions';
+import { isVersionGreaterThan, isVersionLessThan, isNewerVersion, isSameVersion } from './utils/versions';
 import { mergeSpecifications, type Specification, type Specifications } from './utils/specifications';
 import { filterMessagesByRoutes, mergeSends } from './utils/consumers';
 
@@ -612,6 +612,7 @@ const processMessagesForOpenAPISpec = async (
 
     // Check if the message already exists in the catalog
     const catalogedMessage = await getMessage(message.id, 'latest');
+    let shouldWriteMessage = true;
 
     if (catalogedMessage) {
       // always preserve badges and attachments
@@ -623,12 +624,25 @@ const processMessagesForOpenAPISpec = async (
         messageMarkdown = catalogedMessage.markdown;
       }
 
-      // if the version matches, we can override the message but keep markdown as it  was
-      if (catalogedMessage.version !== message.version) {
+      const catalogedVersion = catalogedMessage.version ?? '';
+
+      if (isSameVersion(catalogedVersion, message.version)) {
+        // Same version - overwrite in place
+      } else if (isNewerVersion(message.version, catalogedVersion)) {
         console.log('versioning message', message.id);
-        // if the version does not match, we need to version the message
+        // Incoming is strictly newer - version the cataloged one and write the new one at root
         await versionMessage(message.id);
         console.log(chalk.cyan(` - Versioned previous message: ${message.id} (v${catalogedMessage.version})`));
+      } else {
+        // Incoming is older than (or not confidently newer than) the cataloged version.
+        // Leave the cataloged entry alone and point the service's sends/receives at it.
+        console.log(
+          chalk.yellow(
+            ` - Skipping ${message.id} (v${message.version}) - catalog already has a newer version (v${catalogedVersion})`
+          )
+        );
+        message.version = catalogedVersion;
+        shouldWriteMessage = false;
       }
     }
 
@@ -639,19 +653,21 @@ const processMessagesForOpenAPISpec = async (
     }
 
     // Write the message to the catalog
-    await writeMessage(
-      {
-        ...message,
-        badges: messageBadges || message.badges,
-        markdown: messageMarkdown,
-        ...(options.owners ? { owners: options.owners } : {}),
-        ...(messageAttachments ? { attachments: messageAttachments } : {}),
-        // only if its defined add it to the sidebar
-        ...(sidebarBadgeType === 'HTTP_METHOD' ? { sidebar } : {}),
-        ...(isDraft ? { draft: true } : {}),
-      },
-      { path: options.pathForMessages || messagePath, override: true }
-    );
+    if (shouldWriteMessage) {
+      await writeMessage(
+        {
+          ...message,
+          badges: messageBadges || message.badges,
+          markdown: messageMarkdown,
+          ...(options.owners ? { owners: options.owners } : {}),
+          ...(messageAttachments ? { attachments: messageAttachments } : {}),
+          // only if its defined add it to the sidebar
+          ...(sidebarBadgeType === 'HTTP_METHOD' ? { sidebar } : {}),
+          ...(isDraft ? { draft: true } : {}),
+        },
+        { path: options.pathForMessages || messagePath, override: true }
+      );
+    }
 
     // If the message send or recieved by the service?
     const group = getMessageGroup(operation, options.groupMessagesBy, groupablePrefixes);
@@ -674,7 +690,7 @@ const processMessagesForOpenAPISpec = async (
     });
 
     // Does the message have a request body or responses?
-    if (requestBodiesAndResponses?.requestBody) {
+    if (shouldWriteMessage && requestBodiesAndResponses?.requestBody) {
       await addFileToMessage(
         message.id,
         {
@@ -685,7 +701,7 @@ const processMessagesForOpenAPISpec = async (
       );
     }
 
-    if (requestBodiesAndResponses?.responses) {
+    if (shouldWriteMessage && requestBodiesAndResponses?.responses) {
       for (const [statusCode, schema] of Object.entries(requestBodiesAndResponses.responses)) {
         const getContent = () => {
           try {
@@ -719,7 +735,7 @@ const processMessagesForOpenAPISpec = async (
     }
 
     // Add examples to the message if parseExamples is enabled
-    if (parseExamples && operation.operationId) {
+    if (shouldWriteMessage && parseExamples && operation.operationId) {
       const operationExamples = await getExamplesByOperationId(pathToSpec, operation.operationId, document as any);
       for (const example of operationExamples) {
         await addExampleToMessage(message.id, { content: example.content, fileName: example.fileName }, message.version);

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -1446,6 +1446,28 @@ describe('OpenAPI EventCatalog Plugin', () => {
         expect(newEvent).toBeDefined();
       });
 
+      it('when the incoming message version is older than the cataloged one, the newer cataloged message is not demoted', async () => {
+        // petstore.yml declares info.version 1.0.0, so createPets will be generated at v1.0.0.
+        // The catalog already has v2.0.0 (e.g. from a previous run against a newer spec).
+        // Regenerating from the older spec must NOT demote v2.0.0 and replace it with v1.0.0.
+        const { writeCommand, getCommand } = utils(catalogDir);
+
+        await writeCommand({
+          id: 'createPets',
+          name: 'createPets',
+          version: '2.0.0',
+          summary: 'Create a pet',
+          markdown: 'cataloged at v2.0.0',
+        });
+
+        await plugin(config, { services: [{ path: join(openAPIExamples, 'petstore.yml'), id: 'swagger-petstore' }] });
+
+        const latest = await getCommand('createPets', 'latest');
+        expect(latest).toBeDefined();
+        expect(latest.version).toEqual('2.0.0');
+        expect(latest.markdown).toEqual('cataloged at v2.0.0');
+      });
+
       it('when a the message already exists in EventCatalog the markdown, badges and attachments are persisted and not overwritten by default', async () => {
         const { writeCommand, getCommand } = utils(catalogDir);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
+      semver:
+        specifier: ^7.7.2
+        version: 7.7.3
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
@@ -225,6 +228,9 @@ importers:
       '@types/node':
         specifier: ^20.16.1
         version: 20.19.1
+      '@types/semver':
+        specifier: ^7.7.0
+        version: 7.7.0
       prettier:
         specifier: ^3.3.3
         version: 3.5.3
@@ -363,6 +369,9 @@ importers:
       chalk:
         specifier: 4.1.2
         version: 4.1.2
+      semver:
+        specifier: ^7.7.2
+        version: 7.7.3
       update-notifier:
         specifier: ^7.3.1
         version: 7.3.1
@@ -373,6 +382,9 @@ importers:
       '@types/node':
         specifier: ^20.16.1
         version: 20.19.1
+      '@types/semver':
+        specifier: ^7.7.0
+        version: 7.7.0
       prettier:
         specifier: ^3.3.3
         version: 3.5.3
@@ -5179,7 +5191,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.3
 
   '@changesets/apply-release-plan@7.0.14':
     dependencies:
@@ -5204,7 +5216,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.2
+      semver: 7.7.3
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -5268,7 +5280,7 @@ snapshots:
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.3
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
@@ -5336,7 +5348,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.2
+      semver: 7.7.3
 
   '@changesets/get-release-plan@4.0.13':
     dependencies:
@@ -7980,7 +7992,7 @@ snapshots:
       console-table-printer: 2.14.3
       p-queue: 6.6.2
       p-retry: 4.6.2
-      semver: 7.7.2
+      semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
       openai: 4.104.0(ws@8.18.3)(zod@3.25.67)
@@ -8473,7 +8485,7 @@ snapshots:
     dependencies:
       color: 4.2.3
       detect-libc: 2.0.4
-      semver: 7.7.2
+      semver: 7.7.3
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.2
       '@img/sharp-darwin-x64': 0.34.2


### PR DESCRIPTION
## What This PR Does

The EventBridge, AsyncAPI and OpenAPI generators used a plain `!==` version check before deciding whether to call `versionEvent` / `versionMessage`. Any version difference would demote the cataloged entry into `versioned/` and write the incoming one at the root — even when the incoming version was older. This was the root cause of the Discord report where an EventBridge catalog ended up with `IdentityCreated v99` at the root and `v100` in `versioned/`, since the integer version counter ("99" vs "100") compared lexicographically. The same pattern also bites AsyncAPI and OpenAPI users who regenerate from a snapshot of an older spec.

All three generators now use a semver-aware comparison (with `semver.coerce` so non-semver inputs like `"99"`/`"100"` still sort correctly) and only demote the cataloged entry when the incoming version is strictly newer.

## Changes Overview

### Key Changes

- Added `isNewerVersion` and `isSameVersion` helpers in each generator's `utils/versions.ts`. Both coerce non-semver inputs via `semver.coerce` and fall back to returning `false` when a confident comparison is not possible.
- Replaced the `!==` version check in each generator's message-write path with a three-way branch:
  - **Same version** → overwrite in place (previous behaviour).
  - **Incoming strictly newer** → `versionEvent` / `versionMessage` to demote the cataloged one (previous behaviour).
  - **Incoming older / not confidently newer** → log a warning, skip the write, and point the service's `sends`/`receives` at the existing cataloged version so no broken pointers are produced.
- `shouldWriteMessage` also now gates schema and example writes (`addSchemaToMessage`, `addExampleToMessage`, `addFileToMessage`) so we do not attach artefacts to a version that never made it to disk.
- Added `semver` / `@types/semver` to `generator-eventbridge` and `generator-asyncapi` (`generator-openapi` already depended on them).
- One failing-then-passing test per generator that pre-seeds the catalog with a newer version, runs the generator against an older spec, and asserts the cataloged version stays at root.

## How It Works

`isNewerVersion(incoming, existing)`:

1. Both valid or coercible to semver → use `semver.gt`. "99" and "100" become "99.0.0" and "100.0.0", so 100 > 99 sorts correctly.
2. Otherwise → `false` (callers treat that as "not confidently newer" and skip destructive actions).

`isSameVersion(a, b)` uses coerced semver equality so "1" and "1.0.0" count as the same version.

When the check lands on the "skip" branch, the message is not rewritten, its schema/examples are not re-attached, and the incoming version pointer is rewritten to the cataloged version before being pushed into the service's `sends`/`receives` list. This avoids regressing the catalog while keeping the service correctly connected to the message that is actually on disk.

## Breaking Changes

None. Existing catalogs that are re-generated against a spec with a strictly-newer version behave exactly as before.

Behaviour change worth calling out: regenerating against a spec with an older version now leaves the catalog alone instead of demoting the newer entry. Users relying on the old "any difference demotes" behaviour to intentionally roll back versions will now see a `Skipping <message> (v<older>) - catalog already has a newer version (v<newer>)` warning. Manual intervention (delete the newer versioned folder, or bump the spec) is the intended path for explicit rollbacks.

## Additional Notes

This fix only covers the message/event-versioning site in each generator. The same `!==` pattern still exists at a handful of other call sites and is worth a follow-up:

- EventBridge: domain (line 208), service (line 279).
- AsyncAPI: domain, channel, service.
- OpenAPI: domain. The service logic already uses `isVersionGreaterThan` but silently no-ops on non-semver inputs.

Separately, the user's original Discord report also showed accumulated duplicate entries in the service's `sends:` list. That is a distinct bug in the EventBridge generator's `sends = [...latestServiceInCatalog.sends, ...sends]` merge (no dedupe), not fixed here.

The three new `versions.ts` files are near-duplicates. If we grow this further it is probably time to extract to a workspace-level shared package; cross-package file imports tripped up the vitest resolver when first attempted.