### PR TITLE
AsyncAPI: Derive message ownership from operation action

### DIFF
--- a/.changeset/asyncapi-message-ownership-by-operation-action.md
+++ b/.changeset/asyncapi-message-ownership-by-operation-action.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/generator-asyncapi': major
+---
+
+feat: derive AsyncAPI message ownership from operation action. The same message can appear on multiple services — typically one publishes and others subscribe — but the generator previously treated every service as the owner, so each run overwrote the message's catalog entry from whichever service was processed last. Ownership now follows the operation action: `send`/`publish` claims ownership, while `receive`/`subscribe` only references the existing message without overwriting markdown, badges, or attachments. A new `messageOwnership` config option (`'action-based'` default, `'all-owned'` legacy) preserves the previous behavior for users who relied on it, and an explicit `x-eventcatalog-role` extension still wins over both defaults.

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -141,6 +141,7 @@ const optionsSchema = z.object({
         .optional(),
     })
     .optional(),
+  messageOwnership: z.enum(['action-based', 'all-owned']).optional(),
   debug: z.boolean().optional(),
   parseSchemas: z.boolean().optional(),
   parseChannels: z.boolean().optional(),
@@ -283,6 +284,7 @@ export default async (config: any, options: Props) => {
     parseChannels = false,
     parseExamples = true,
     attachHeadersToSchema = false,
+    messageOwnership = 'action-based',
   } = options;
   // const asyncAPIFiles = Array.isArray(options.path) ? options.path : [options.path];
   console.log(chalk.green(`Processing ${services.length} AsyncAPI files...`));
@@ -486,7 +488,7 @@ export default async (config: any, options: Props) => {
           isDomainMarkedAsDraft || isServiceMarkedAsDraft || message.extensions().get('x-eventcatalog-draft')?.value() || null;
 
         // does this service own or just consume the message?
-        const serviceOwnsMessageContract = isServiceMessageOwner(message, operation);
+        const serviceOwnsMessageContract = isServiceMessageOwner(message, operation, messageOwnership);
         const isReceived = operation.action() === 'receive' || operation.action() === 'subscribe';
         const isSent = operation.action() === 'send' || operation.action() === 'publish';
 
@@ -845,18 +847,25 @@ const isJSONSchemaMessage = (message: MessageInterface) => {
  *
  * default is provider (AsyncAPI file / service owns the message)
  */
-const isServiceMessageOwner = (message: MessageInterface, operation?: { extensions: () => any; action?: () => string }): boolean => {
+const isServiceMessageOwner = (
+  message: MessageInterface,
+  operation?: { extensions: () => any; action?: () => string },
+  messageOwnership: string = 'action-based'
+): boolean => {
   // Prefer operation-level override to support shared/ref'ed messages where ownership
   // needs to be set per operation/service.
   const operationRole = operation?.extensions?.().get?.('x-eventcatalog-role')?.value?.();
   const messageRole = message.extensions().get('x-eventcatalog-role')?.value();
 
-  // If explicitly set, use that value
+  // x-eventcatalog-role always takes priority
   if (operationRole || messageRole) {
     return (operationRole || messageRole) === 'provider';
   }
 
-  // Default: only senders/publishers own messages
+  // Config-driven default: all messages treated as owned
+  if (messageOwnership === 'all-owned') return true;
+
+  // action-based default: only senders/publishers own messages
   const action = operation?.action?.();
   if (action === 'receive' || action === 'subscribe') {
     return false;

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -530,10 +530,11 @@ export default async (config: any, options: Props) => {
           messagePath = messageId;
         }
 
+        let shouldWriteMessage = true;
+
         if (serviceOwnsMessageContract) {
           // Check if the message already exists in the catalog
           const catalogedMessage = await getMessage(messageId, 'latest');
-          let shouldWriteMessage = true;
 
           if (catalogedMessage) {
             // persist markdown, badges and attachments if it exists
@@ -561,73 +562,74 @@ export default async (config: any, options: Props) => {
               shouldWriteMessage = false;
             }
           }
+        }
 
-          if (shouldWriteMessage) {
-            await writeMessage(
-              {
-                id: messageId,
-                version: messageVersion,
-                name: getMessageName(message),
-                summary: getMessageSummary(message),
-                markdown: messageMarkdown,
-                badges:
-                  messageBadges || badges.map((badge) => ({ content: badge.name(), textColor: 'blue', backgroundColor: 'blue' })),
-                ...(messageHasSchema(message) && { schemaPath: getSchemaFileName(message) }),
-                ...(owners && { owners }),
-                ...(messageAttachments && { attachments: messageAttachments }),
-                ...(deprecatedDate && {
-                  deprecated: { date: deprecatedDate, ...(deprecatedMessage && { message: deprecatedMessage }) },
-                }),
-                ...(isMessageMarkedAsDraft && { draft: true }),
-              },
-              {
-                override: true,
-                path: messagePath,
-              }
-            );
-
-            console.log(chalk.cyan(` - Message (v${messageVersion}) created`));
-
-            // Check if the message has a payload, if it does then document in EventCatalog
-            if (messageHasSchema(message)) {
-              const schema = getSchemaForMessage(message, attachHeadersToSchema);
-
-              // Normalize path separators and remove leading relative path segments (../ or ./ for both Unix and Windows)
-              const cleanedMessagePath = messagePath
-                .replace(/\\/g, '/') // Convert all backslashes to forward slashes
-                .replace(/^(\.\.\/|\.\/)+/g, ''); // Remove all leading ../ or ./ segments
-
-              await addSchemaToMessage(
-                messageId,
-                {
-                  fileName: getSchemaFileName(message),
-                  schema: safeStringify(schema, 4),
-                },
-                messageVersion,
-                { path: cleanedMessagePath }
-              );
-              console.log(chalk.cyan(` - Schema added to message (v${messageVersion})`));
+        if (shouldWriteMessage) {
+          await writeMessage(
+            {
+              id: messageId,
+              version: messageVersion,
+              name: getMessageName(message),
+              summary: getMessageSummary(message),
+              markdown: messageMarkdown,
+              badges:
+                messageBadges || badges.map((badge) => ({ content: badge.name(), textColor: 'blue', backgroundColor: 'blue' })),
+              ...(messageHasSchema(message) && { schemaPath: getSchemaFileName(message) }),
+              ...(owners && { owners }),
+              ...(messageAttachments && { attachments: messageAttachments }),
+              ...(deprecatedDate && {
+                deprecated: { date: deprecatedDate, ...(deprecatedMessage && { message: deprecatedMessage }) },
+              }),
+              ...(isMessageMarkedAsDraft && { draft: true }),
+            },
+            {
+              override: serviceOwnsMessageContract,
+              path: messagePath,
             }
+          );
 
-            // Add examples to the message if parseExamples is enabled
-            if (parseExamples) {
-              const messageExamples = message.examples().all();
-              for (let i = 0; i < messageExamples.length; i++) {
-                const example = messageExamples[i];
-                const payload = example.payload();
-                if (payload) {
-                  const fileName = example.hasName() ? `${example.name()}.json` : `example-${i}.json`;
-                  await addExampleToMessage(messageId, { content: JSON.stringify(payload, null, 2), fileName }, messageVersion);
-                }
+          console.log(
+            chalk.cyan(
+              ` - Message (v${messageVersion}) ${serviceOwnsMessageContract ? 'created' : 'written (non-owner, override: false)'}`
+            )
+          );
+
+          // Check if the message has a payload, if it does then document in EventCatalog
+          if (messageHasSchema(message)) {
+            const schema = getSchemaForMessage(message, attachHeadersToSchema);
+
+            // Normalize path separators and remove leading relative path segments (../ or ./ for both Unix and Windows)
+            const cleanedMessagePath = messagePath
+              .replace(/\\/g, '/') // Convert all backslashes to forward slashes
+              .replace(/^(\.\.\/|\.\/)+/g, ''); // Remove all leading ../ or ./ segments
+
+            await addSchemaToMessage(
+              messageId,
+              {
+                fileName: getSchemaFileName(message),
+                schema: safeStringify(schema, 4),
+              },
+              messageVersion,
+              { path: cleanedMessagePath }
+            );
+            console.log(chalk.cyan(` - Schema added to message (v${messageVersion})`));
+          }
+
+          // Add examples to the message if parseExamples is enabled
+          if (parseExamples) {
+            const messageExamples = message.examples().all();
+            for (let i = 0; i < messageExamples.length; i++) {
+              const example = messageExamples[i];
+              const payload = example.payload();
+              if (payload) {
+                const fileName = example.hasName() ? `${example.name()}.json` : `example-${i}.json`;
+                await addExampleToMessage(messageId, { content: JSON.stringify(payload, null, 2), fileName }, messageVersion);
               }
-              if (messageExamples.length > 0) {
-                console.log(chalk.cyan(` - ${messageExamples.length} example(s) added to message (v${messageVersion})`));
-              }
+            }
+            if (messageExamples.length > 0) {
+              console.log(chalk.cyan(` - ${messageExamples.length} example(s) added to message (v${messageVersion})`));
             }
           }
-        } else {
-          // Message is not owned by this service, therefore we don't need to document it
-          console.log(chalk.yellow(` - Skipping external message: ${getMessageName(message)}(v${messageVersion})`));
         }
         // Derive group from x-eventcatalog-group extension if groupMessagesBy is configured
         const group =
@@ -843,11 +845,21 @@ const isJSONSchemaMessage = (message: MessageInterface) => {
  *
  * default is provider (AsyncAPI file / service owns the message)
  */
-const isServiceMessageOwner = (message: MessageInterface, operation?: { extensions: () => any }): boolean => {
+const isServiceMessageOwner = (message: MessageInterface, operation?: { extensions: () => any; action?: () => string }): boolean => {
   // Prefer operation-level override to support shared/ref'ed messages where ownership
   // needs to be set per operation/service.
   const operationRole = operation?.extensions?.().get?.('x-eventcatalog-role')?.value?.();
   const messageRole = message.extensions().get('x-eventcatalog-role')?.value();
-  const value = operationRole || messageRole || 'provider';
-  return value === 'provider';
+
+  // If explicitly set, use that value
+  if (operationRole || messageRole) {
+    return (operationRole || messageRole) === 'provider';
+  }
+
+  // Default: only senders/publishers own messages
+  const action = operation?.action?.();
+  if (action === 'receive' || action === 'subscribe') {
+    return false;
+  }
+  return true;
 };

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -564,6 +564,13 @@ export default async (config: any, options: Props) => {
               shouldWriteMessage = false;
             }
           }
+        } else {
+          // Non-owner: if the message already exists, skip writing to avoid duplicates
+          const catalogedMessage = await getMessage(messageId, 'latest');
+          if (catalogedMessage) {
+            console.log(chalk.cyan(` - Message ${messageId} (v${messageVersion}) already exists, skipping (non-owner)`));
+            shouldWriteMessage = false;
+          }
         }
 
         if (shouldWriteMessage) {

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -534,10 +534,10 @@ export default async (config: any, options: Props) => {
 
         let shouldWriteMessage = true;
 
-        if (serviceOwnsMessageContract) {
-          // Check if the message already exists in the catalog
-          const catalogedMessage = await getMessage(messageId, 'latest');
+        // Check if the message already exists in the catalog
+        const catalogedMessage = await getMessage(messageId, 'latest');
 
+        if (serviceOwnsMessageContract) {
           if (catalogedMessage) {
             // persist markdown, badges and attachments if it exists
             messageMarkdown = catalogedMessage.markdown;
@@ -566,7 +566,6 @@ export default async (config: any, options: Props) => {
           }
         } else {
           // Non-owner: if the message already exists, skip writing to avoid duplicates
-          const catalogedMessage = await getMessage(messageId, 'latest');
           if (catalogedMessage) {
             console.log(chalk.cyan(` - Message ${messageId} (v${messageVersion}) already exists, skipping (non-owner)`));
             shouldWriteMessage = false;

--- a/packages/generator-asyncapi/src/test/asyncapi-files/publisher-service.asyncapi.yml
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/publisher-service.asyncapi.yml
@@ -1,0 +1,48 @@
+asyncapi: 3.0.0
+info:
+  title: Order Service
+  version: 1.0.0
+  description: Service that publishes order events
+channels:
+  orderPlaced:
+    address: orders/placed
+    messages:
+      OrderPlaced:
+        $ref: '#/components/messages/OrderPlaced'
+operations:
+  sendOrderPlaced:
+    action: send
+    channel:
+      $ref: '#/channels/orderPlaced'
+    messages:
+      - $ref: '#/channels/orderPlaced/messages/OrderPlaced'
+components:
+  messages:
+    OrderPlaced:
+      description: 'An order has been placed'
+      x-eventcatalog-message-type: event
+      payload:
+        type: object
+        properties:
+          orderId:
+            type: string
+            description: Unique order identifier
+          userId:
+            type: string
+            description: ID of the user who placed the order
+          amount:
+            type: number
+            description: Total order amount
+          currency:
+            type: string
+            description: Currency code
+          items:
+            type: array
+            description: List of items in the order
+            items:
+              type: object
+              properties:
+                productId:
+                  type: string
+                quantity:
+                  type: integer

--- a/packages/generator-asyncapi/src/test/asyncapi-files/sender-client-role.asyncapi.yml
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/sender-client-role.asyncapi.yml
@@ -1,0 +1,28 @@
+asyncapi: 3.0.0
+info:
+  title: Sender Client Role Service
+  version: 1.0.0
+channels:
+  orderPlaced:
+    address: orders/placed
+    messages:
+      OrderPlaced:
+        $ref: '#/components/messages/OrderPlaced'
+operations:
+  sendOrderPlaced:
+    action: send
+    x-eventcatalog-role: client
+    channel:
+      $ref: '#/channels/orderPlaced'
+    messages:
+      - $ref: '#/channels/orderPlaced/messages/OrderPlaced'
+components:
+  messages:
+    OrderPlaced:
+      description: 'An order has been placed (client sender)'
+      x-eventcatalog-message-type: event
+      payload:
+        type: object
+        properties:
+          orderId:
+            type: string

--- a/packages/generator-asyncapi/src/test/asyncapi-files/subscriber-provider-role.asyncapi.yml
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/subscriber-provider-role.asyncapi.yml
@@ -1,0 +1,28 @@
+asyncapi: 3.0.0
+info:
+  title: Subscriber Provider Service
+  version: 1.0.0
+channels:
+  orderPlaced:
+    address: orders/placed
+    messages:
+      OrderPlaced:
+        $ref: '#/components/messages/OrderPlaced'
+operations:
+  receiveOrderPlaced:
+    action: receive
+    x-eventcatalog-role: provider
+    channel:
+      $ref: '#/channels/orderPlaced'
+    messages:
+      - $ref: '#/channels/orderPlaced/messages/OrderPlaced'
+components:
+  messages:
+    OrderPlaced:
+      description: 'An order has been placed (provider subscriber)'
+      x-eventcatalog-message-type: event
+      payload:
+        type: object
+        properties:
+          orderId:
+            type: string

--- a/packages/generator-asyncapi/src/test/asyncapi-files/subscriber-service.asyncapi.yml
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/subscriber-service.asyncapi.yml
@@ -1,0 +1,32 @@
+asyncapi: 3.0.0
+info:
+  title: Notification Service
+  version: 1.0.0
+  description: Service that subscribes to order events for notifications
+channels:
+  orderPlaced:
+    address: orders/placed
+    messages:
+      OrderPlaced:
+        $ref: '#/components/messages/OrderPlaced'
+operations:
+  receiveOrderPlaced:
+    action: receive
+    channel:
+      $ref: '#/channels/orderPlaced'
+    messages:
+      - $ref: '#/channels/orderPlaced/messages/OrderPlaced'
+components:
+  messages:
+    OrderPlaced:
+      description: 'An order has been placed (subscriber view)'
+      x-eventcatalog-message-type: event
+      payload:
+        type: object
+        properties:
+          orderId:
+            type: string
+            description: Unique order identifier
+          userId:
+            type: string
+            description: ID of the user who placed the order

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -2900,6 +2900,34 @@ describe('AsyncAPI EventCatalog Plugin', () => {
           const subscriberService = await getService('notification-service', '1.0.0');
           expect(subscriberService.receives).toEqual([{ id: 'OrderPlaced', version: '1.0.0' }]);
         });
+
+        it('non-owner subscriber does not create a duplicate message at its own service path', async () => {
+          const { getService } = utils(catalogDir);
+
+          // Publisher creates the message first
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'publisher-service.asyncapi.yml'), id: 'order-service' }],
+          });
+
+          // Subscriber references the same message
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'subscriber-service.asyncapi.yml'), id: 'notification-service' }],
+          });
+
+          // Message should exist at the publisher's path
+          expect(existsSync(join(catalogDir, 'services', 'order-service', 'events', 'OrderPlaced'))).toBe(true);
+
+          // Message should NOT exist at the subscriber's path (no duplicate)
+          expect(existsSync(join(catalogDir, 'services', 'notification-service', 'events', 'OrderPlaced'))).toBe(false);
+
+          // Subscriber service should still list the message in receives
+          const subscriberService = await getService('notification-service', '1.0.0');
+          expect(subscriberService.receives).toEqual([{ id: 'OrderPlaced', version: '1.0.0' }]);
+
+          // Publisher service should still list the message in sends
+          const publisherService = await getService('order-service', '1.0.0');
+          expect(publisherService.sends).toEqual([{ id: 'OrderPlaced', version: '1.0.0' }]);
+        });
       });
 
       describe('all-owned', () => {

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -1436,7 +1436,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
       expect(newEvent.markdown).toEqual('please dont override me!');
     });
 
-    it('when the `x-eventcatalog-role` is defined and set to `client` the generator does not create or modify the message documentation, but still included in the service (sends/receives)', async () => {
+    it('when the `x-eventcatalog-role` is defined and set to `client` the message is written with override: false but still included in the service (sends/receives)', async () => {
       const { getEvent } = utils(catalogDir);
       const { getService } = utils(catalogDir);
 
@@ -1445,8 +1445,9 @@ describe('AsyncAPI EventCatalog Plugin', () => {
       const service = await getService('account-service', '1.0.0');
       const newEvent = await getEvent('UserSubscribed', 'latest');
 
-      // Event was not added to the EventCatalog
-      expect(newEvent).toBeUndefined();
+      // Event is created (with override: false) even though this service is a client
+      expect(newEvent).toBeDefined();
+      expect(newEvent.name).toEqual('UserSubscribed');
 
       expect(service.receives).toEqual([
         { id: 'SignUpUser', version: '2.0.0' },
@@ -1457,7 +1458,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
       ]);
     });
 
-    it('when `x-eventcatalog-role` is defined on an operation and set to `client`, the message is treated as external', async () => {
+    it('when `x-eventcatalog-role` is defined on an operation and set to `client`, the message is written with override: false', async () => {
       const { getEvent } = utils(catalogDir);
       const { getService } = utils(catalogDir);
 
@@ -1468,7 +1469,9 @@ describe('AsyncAPI EventCatalog Plugin', () => {
       const service = await getService('account-service', '1.0.0');
       const event = await getEvent('UserSignedUp', 'latest');
 
-      expect(event).toBeUndefined();
+      // Event is created (with override: false) even though this service is a client
+      expect(event).toBeDefined();
+      expect(event.name).toEqual('UserSignedUp');
       expect(service.receives).toContainEqual({ id: 'UserSignedUp', version: '1.0.0' });
     });
 
@@ -2473,7 +2476,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         expect(service.schemaPath).toEqual('simple.asyncapi.yml');
 
         const events = await fs.readdir(join(catalogDir, 'events'));
-        expect(events).toEqual(['UserSignedOut', 'UserSignedUp']);
+        expect(events).toEqual(['UserSignedOut', 'UserSignedUp', 'UserSubscribed']);
 
         const queries = await fs.readdir(join(catalogDir, 'queries'));
         expect(queries).toEqual(['CheckEmailAvailability', 'GetUserByEmail']);
@@ -2871,6 +2874,90 @@ describe('AsyncAPI EventCatalog Plugin', () => {
 
         expect(examples).toHaveLength(1);
         expect(examples[0].fileName).toEqual('example-0.json');
+      });
+    });
+
+    describe('default message ownership', () => {
+      it('when publisher and subscriber both define the same message, subscriber does not override publisher schema', async () => {
+        const { getEvent, getService } = utils(catalogDir);
+
+        // Run publisher first — creates OrderPlaced with full schema
+        await plugin(config, {
+          services: [{ path: join(asyncAPIExamplesDir, 'publisher-service.asyncapi.yml'), id: 'order-service' }],
+        });
+
+        // Run subscriber second — should NOT overwrite the message
+        await plugin(config, {
+          services: [{ path: join(asyncAPIExamplesDir, 'subscriber-service.asyncapi.yml'), id: 'notification-service' }],
+        });
+
+        // The event should still have the publisher's full schema
+        const event = await getEvent('OrderPlaced', 'latest');
+        expect(event).toBeDefined();
+
+        // Read the schema file and verify it has all publisher fields
+        const schema = JSON.parse(
+          await fs.readFile(join(catalogDir, 'services', 'order-service', 'events', 'OrderPlaced', 'schema.json'), 'utf-8')
+        );
+        expect(schema.properties).toHaveProperty('orderId');
+        expect(schema.properties).toHaveProperty('userId');
+        expect(schema.properties).toHaveProperty('amount');
+        expect(schema.properties).toHaveProperty('currency');
+        expect(schema.properties).toHaveProperty('items');
+
+        // The subscriber service should still receive the message
+        const subscriberService = await getService('notification-service', '1.0.0');
+        expect(subscriberService.receives).toEqual([{ id: 'OrderPlaced', version: '1.0.0' }]);
+      });
+
+      it('when a receive operation has explicit x-eventcatalog-role: provider, it still owns the message', async () => {
+        const { getEvent } = utils(catalogDir);
+
+        // publisher-service sends OrderPlaced, subscriber-service receives it
+        // but we add explicit provider role to subscriber's operation
+        // Create a temporary fixture with explicit provider role on receive
+        const subscriberWithProviderRole = join(catalogDir, 'subscriber-provider.asyncapi.yml');
+        await fs.mkdir(catalogDir, { recursive: true });
+        await fs.writeFile(
+          subscriberWithProviderRole,
+          `asyncapi: 3.0.0
+info:
+  title: Subscriber Provider Service
+  version: 1.0.0
+channels:
+  orderPlaced:
+    address: orders/placed
+    messages:
+      OrderPlaced:
+        $ref: '#/components/messages/OrderPlaced'
+operations:
+  receiveOrderPlaced:
+    action: receive
+    x-eventcatalog-role: provider
+    channel:
+      $ref: '#/channels/orderPlaced'
+    messages:
+      - $ref: '#/channels/orderPlaced/messages/OrderPlaced'
+components:
+  messages:
+    OrderPlaced:
+      description: 'An order has been placed (provider subscriber)'
+      x-eventcatalog-message-type: event
+      payload:
+        type: object
+        properties:
+          orderId:
+            type: string
+`
+        );
+
+        await plugin(config, {
+          services: [{ path: subscriberWithProviderRole, id: 'subscriber-provider-service' }],
+        });
+
+        const event = await getEvent('OrderPlaced', 'latest');
+        expect(event).toBeDefined();
+        expect(event.schemaPath).toEqual('schema.json');
       });
     });
   });

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -2877,87 +2877,84 @@ describe('AsyncAPI EventCatalog Plugin', () => {
       });
     });
 
-    describe('default message ownership', () => {
-      it('when publisher and subscriber both define the same message, subscriber does not override publisher schema', async () => {
-        const { getEvent, getService } = utils(catalogDir);
+    describe('messageOwnership option', () => {
+      describe('action-based (default)', () => {
+        it('subscriber does not overwrite publisher schema', async () => {
+          const { getEvent, getService } = utils(catalogDir);
 
-        // Run publisher first — creates OrderPlaced with full schema
-        await plugin(config, {
-          services: [{ path: join(asyncAPIExamplesDir, 'publisher-service.asyncapi.yml'), id: 'order-service' }],
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'publisher-service.asyncapi.yml'), id: 'order-service' }],
+          });
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'subscriber-service.asyncapi.yml'), id: 'notification-service' }],
+          });
+
+          const schema = JSON.parse(
+            await fs.readFile(join(catalogDir, 'services', 'order-service', 'events', 'OrderPlaced', 'schema.json'), 'utf-8')
+          );
+          expect(schema.properties).toHaveProperty('orderId');
+          expect(schema.properties).toHaveProperty('amount');
+          expect(schema.properties).toHaveProperty('currency');
+          expect(schema.properties).toHaveProperty('items');
+
+          const subscriberService = await getService('notification-service', '1.0.0');
+          expect(subscriberService.receives).toEqual([{ id: 'OrderPlaced', version: '1.0.0' }]);
         });
-
-        // Run subscriber second — should NOT overwrite the message
-        await plugin(config, {
-          services: [{ path: join(asyncAPIExamplesDir, 'subscriber-service.asyncapi.yml'), id: 'notification-service' }],
-        });
-
-        // The event should still have the publisher's full schema
-        const event = await getEvent('OrderPlaced', 'latest');
-        expect(event).toBeDefined();
-
-        // Read the schema file and verify it has all publisher fields
-        const schema = JSON.parse(
-          await fs.readFile(join(catalogDir, 'services', 'order-service', 'events', 'OrderPlaced', 'schema.json'), 'utf-8')
-        );
-        expect(schema.properties).toHaveProperty('orderId');
-        expect(schema.properties).toHaveProperty('userId');
-        expect(schema.properties).toHaveProperty('amount');
-        expect(schema.properties).toHaveProperty('currency');
-        expect(schema.properties).toHaveProperty('items');
-
-        // The subscriber service should still receive the message
-        const subscriberService = await getService('notification-service', '1.0.0');
-        expect(subscriberService.receives).toEqual([{ id: 'OrderPlaced', version: '1.0.0' }]);
       });
 
-      it('when a receive operation has explicit x-eventcatalog-role: provider, it still owns the message', async () => {
-        const { getEvent } = utils(catalogDir);
+      describe('all-owned', () => {
+        it('subscriber overwrites existing message (override: true)', async () => {
+          const { writeEvent, getEvent, getService } = utils(catalogDir);
 
-        // publisher-service sends OrderPlaced, subscriber-service receives it
-        // but we add explicit provider role to subscriber's operation
-        // Create a temporary fixture with explicit provider role on receive
-        const subscriberWithProviderRole = join(catalogDir, 'subscriber-provider.asyncapi.yml');
-        await fs.mkdir(catalogDir, { recursive: true });
-        await fs.writeFile(
-          subscriberWithProviderRole,
-          `asyncapi: 3.0.0
-info:
-  title: Subscriber Provider Service
-  version: 1.0.0
-channels:
-  orderPlaced:
-    address: orders/placed
-    messages:
-      OrderPlaced:
-        $ref: '#/components/messages/OrderPlaced'
-operations:
-  receiveOrderPlaced:
-    action: receive
-    x-eventcatalog-role: provider
-    channel:
-      $ref: '#/channels/orderPlaced'
-    messages:
-      - $ref: '#/channels/orderPlaced/messages/OrderPlaced'
-components:
-  messages:
-    OrderPlaced:
-      description: 'An order has been placed (provider subscriber)'
-      x-eventcatalog-message-type: event
-      payload:
-        type: object
-        properties:
-          orderId:
-            type: string
-`
-        );
+          await writeEvent({ id: 'OrderPlaced', version: '1.0.0', name: 'OrderPlaced', markdown: 'should be overwritten' });
 
-        await plugin(config, {
-          services: [{ path: subscriberWithProviderRole, id: 'subscriber-provider-service' }],
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'subscriber-service.asyncapi.yml'), id: 'notification-service' }],
+            messageOwnership: 'all-owned',
+          });
+
+          const event = await getEvent('OrderPlaced', 'latest');
+          expect(event).toBeDefined();
+          // Plugin preserves markdown of existing owned messages, proving it entered the owner code path
+          expect(event.markdown).toEqual('should be overwritten');
+          expect(event.name).toEqual('OrderPlaced');
+
+          const subscriberService = await getService('notification-service', '1.0.0');
+          expect(subscriberService.receives).toEqual([{ id: 'OrderPlaced', version: '1.0.0' }]);
+        });
+      });
+
+      describe('x-eventcatalog-role always takes priority over messageOwnership config', () => {
+        it('receive + x-eventcatalog-role: provider → owns the message', async () => {
+          const { getEvent } = utils(catalogDir);
+
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'subscriber-provider-role.asyncapi.yml'), id: 'subscriber-provider-service' }],
+          });
+
+          const event = await getEvent('OrderPlaced', 'latest');
+          expect(event).toBeDefined();
+          expect(event.schemaPath).toEqual('schema.json');
         });
 
-        const event = await getEvent('OrderPlaced', 'latest');
-        expect(event).toBeDefined();
-        expect(event.schemaPath).toEqual('schema.json');
+        it('all-owned + x-eventcatalog-role: client → does not overwrite', async () => {
+          const { getEvent } = utils(catalogDir);
+
+          // Publisher creates the message as owner
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'publisher-service.asyncapi.yml'), id: 'order-service' }],
+          });
+          const originalMarkdown = (await getEvent('OrderPlaced', 'latest')).markdown;
+
+          // Despite all-owned, explicit client role prevents overwriting
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'sender-client-role.asyncapi.yml'), id: 'sender-client-role-service' }],
+            messageOwnership: 'all-owned',
+          });
+
+          const event = await getEvent('OrderPlaced', 'latest');
+          expect(event.markdown).toEqual(originalMarkdown);
+        });
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

In AsyncAPI, the same message can appear on multiple services — typically one service publishes it and others subscribe — but the previous generator treated every service as the owner, causing each run to overwrite the message's catalog entry from whichever service was processed last. EventCatalog models this relationship explicitly (a service either produces or consumes a message, and only the producer owns it), so ownership now follows the AsyncAPI operation action: `send`/`publish` claims ownership, while `receive`/`subscribe` only references the existing message without overwriting it. A `messageOwnership` config flag preserves the old "everyone owns everything" behavior for users who relied on it, and an explicit `x-eventcatalog-role` extension still wins over both defaults.