### PR TITLE
fix(openapi): handle circular references when writing request body schemas

### DIFF
--- a/.changeset/circular-schema-stringify.md
+++ b/.changeset/circular-schema-stringify.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/generator-openapi': patch
+---
+
+fix: handle circular references when writing request body schemas to disk. The OpenAPI generator previously wrapped only response schema serialization with a circular-safe `JSON.stringify` replacer, so request bodies containing circular `$ref`s (e.g. self-referencing `oneOf`/`allOf` constructs) would throw and abort schema file generation. Request body and response serialization now share a single circular-safe stringifier that marks cycles with `"[Circular]"`, so messages with recursive schemas still get a `request-body.json` / `response-*.json` written out.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Dependencies
 node_modules
+.pnpm-store
 .pnp
 .pnp.js
 

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -52,6 +52,22 @@ const toUniqueArray = (array: Pointer[]) => {
   return array.filter((item, index, self) => index === self.findIndex((t) => t.id === item.id && t.version === item.version));
 };
 
+const stringifySchema = (schema: unknown) => {
+  const seen = new WeakSet();
+
+  return JSON.stringify(
+    schema,
+    (_key, value) => {
+      if (typeof value === 'object' && value !== null) {
+        if (seen.has(value)) return '[Circular]';
+        seen.add(value);
+      }
+      return value;
+    },
+    2
+  );
+};
+
 // Merge freshly-generated pointers with pointers already in the catalog, letting the
 // freshly-generated ones win on id+version collisions. This ensures fields derived from
 // current generator options (e.g. `group`) reflect the latest config on re-runs, while
@@ -695,7 +711,7 @@ const processMessagesForOpenAPISpec = async (
         message.id,
         {
           fileName: 'request-body.json',
-          content: JSON.stringify(requestBodiesAndResponses.requestBody, null, 2),
+          content: stringifySchema(requestBodiesAndResponses.requestBody),
         },
         message.version
       );
@@ -703,31 +719,11 @@ const processMessagesForOpenAPISpec = async (
 
     if (shouldWriteMessage && requestBodiesAndResponses?.responses) {
       for (const [statusCode, schema] of Object.entries(requestBodiesAndResponses.responses)) {
-        const getContent = () => {
-          try {
-            return JSON.stringify(schema, null, 2);
-          } catch (error) {
-            // Handle circular references in JSON.stringify
-            const seen = new WeakSet();
-            return JSON.stringify(
-              schema,
-              (key, value) => {
-                if (typeof value === 'object' && value !== null) {
-                  if (seen.has(value)) return '[Circular]'; // Handle circular references
-                  seen.add(value);
-                }
-                return value;
-              },
-              2
-            );
-          }
-        };
-
         await addFileToMessage(
           message.id,
           {
             fileName: `response-${statusCode}.json`,
-            content: getContent(),
+            content: stringifySchema(schema),
           },
           message.version
         );

--- a/packages/generator-openapi/src/test/openapi-files/circular-request-body.json
+++ b/packages/generator-openapi/src/test/openapi-files/circular-request-body.json
@@ -1,0 +1,159 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "example",
+    "version": "0"
+  },
+  "paths": {
+    "/api/example/v0/operations/create": {
+      "post": {
+        "operationId": "createOperation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OperationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationResult"
+                }
+              }
+            },
+            "description": "Successful operation"
+          }
+        },
+        "summary": "Create a generic operation when the provided request matches the approved result.",
+        "tags": ["operation-controller"]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "OperationRequest": {
+        "required": ["approvedEvaluationResult", "definition"],
+        "type": "object",
+        "properties": {
+          "approvedEvaluationResult": {
+            "$ref": "#/components/schemas/EvaluationResult"
+          },
+          "definition": {
+            "$ref": "#/components/schemas/OperationDefinition"
+          }
+        }
+      },
+      "OperationDefinition": {
+        "required": ["resourceId"],
+        "type": "object",
+        "properties": {
+          "resourceId": {
+            "type": "string"
+          }
+        }
+      },
+      "EvaluationResult": {
+        "required": ["resourceEvaluations"],
+        "type": "object",
+        "properties": {
+          "resourceEvaluations": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceEvaluation"
+            }
+          }
+        }
+      },
+      "ResourceEvaluation": {
+        "required": ["itemEvaluations"],
+        "type": "object",
+        "properties": {
+          "itemEvaluations": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ItemEvaluation"
+            }
+          }
+        }
+      },
+      "ItemEvaluation": {
+        "required": ["detailEvaluations"],
+        "type": "object",
+        "properties": {
+          "detailEvaluations": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DetailEvaluation"
+            }
+          }
+        }
+      },
+      "DetailEvaluation": {
+        "required": ["effects"],
+        "type": "object",
+        "properties": {
+          "effects": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DetailEffect"
+            }
+          }
+        }
+      },
+      "DetailEffect": {
+        "required": ["type"],
+        "type": "object",
+        "properties": {
+          "changes": {
+            "$ref": "#/components/schemas/DetailChangeSet"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "discriminator": {
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DetailHiddenEffect"
+          }
+        ]
+      },
+      "DetailChangeSet": {
+        "type": "object",
+        "properties": {
+          "isHidden": {
+            "type": "boolean"
+          }
+        }
+      },
+      "DetailHiddenEffect": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DetailEffect"
+          }
+        ]
+      },
+      "OperationResult": {
+        "type": "object",
+        "properties": {
+          "operationId": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -2152,6 +2152,25 @@ describe('OpenAPI EventCatalog Plugin', () => {
 }`);
     });
 
+    it('when a request body contains circular oneOf/allOf references, the generated schema keeps the shape and marks the cycle', async () => {
+      await plugin(config, {
+        services: [{ path: join(openAPIExamples, 'circular-request-body.json'), id: 'circular-request-body-service' }],
+      });
+
+      const schema = await fs.readFile(
+        join(catalogDir, 'services', 'circular-request-body-service', 'queries', 'createOperation', 'request-body.json'),
+        'utf8'
+      );
+      const parsedSchema = JSON.parse(schema);
+      const detailEffect =
+        parsedSchema.properties.approvedEvaluationResult.properties.resourceEvaluations.items.properties.itemEvaluations.items
+          .properties.detailEvaluations.items.properties.effects.items;
+
+      expect(parsedSchema.properties.definition.properties.resourceId.type).toEqual('string');
+      expect(detailEffect.properties.changes.properties.isHidden.type).toEqual('boolean');
+      expect(detailEffect.oneOf[0].allOf[0]).toEqual('[Circular]');
+    });
+
     describe('persisted data', () => {
       it('when the OpenAPI service is already defined in EventCatalog and the versions match, the styles are persisted and not overwritten', async () => {
         // Create a service with the same name and version as the OpenAPI file for testing


### PR DESCRIPTION
## What This PR Does

The OpenAPI generator previously only guarded response-schema serialization against circular references. Request bodies that contained circular `$ref`s (for example self-referencing `oneOf` / `allOf` constructs) would cause `JSON.stringify` to throw, aborting the schema file write for that message. This PR reuses a single circular-safe stringifier for both request bodies and responses so recursive schemas still produce a `request-body.json` / `response-*.json` with cycles marked as `"[Circular]"`.

## Changes Overview

### Key Changes

- Extract a `stringifySchema` helper that walks the schema with a `WeakSet` and replaces seen objects with `"[Circular]"`.
- Use the helper for both `request-body.json` and `response-*.json` writes in `processMessagesForOpenAPISpec`.
- Add a regression test plus a `circular-request-body.json` fixture exercising deeply nested `oneOf` / `allOf` cycles.
- Minor: ignore `.pnpm-store` and fix trailing newline in root `.gitignore`.

## How It Works

`stringifySchema` is a thin wrapper around `JSON.stringify` with a replacer that tracks visited objects in a `WeakSet`. When the same object reference is encountered a second time during serialization, it is emitted as the string `"[Circular]"` instead of recursing. The existing response-side `try/catch` + inline replacer is removed in favor of calling this helper directly, and the request-body branch is updated to use it as well.

The new test feeds an OpenAPI spec whose request body schema has a cycle via `oneOf` → `allOf` back to an ancestor, then asserts:

- Non-circular fields still serialize with their original types.
- The cycle point in the request body is replaced with the `"[Circular]"` sentinel.

## Breaking Changes

None. Output for non-circular schemas is byte-identical; only previously-failing circular request bodies are affected.

## Additional Notes

- Changeset: `@eventcatalog/generator-openapi` patch.
- No public API changes; helper is module-local.