### PR TITLE
feat(asyncapi): derive message ownership from operation action

### DIFF
--- a/.changeset/asyncapi-action-based-ownership.md
+++ b/.changeset/asyncapi-action-based-ownership.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/generator-asyncapi': minor
+---
+
+feat(asyncapi): take the operation action into account when deciding message ownership. Previously every service overwrote the message it referenced, so a subscriber could clobber the publisher's catalog entry. Now, when no explicit `x-eventcatalog-role` is set, a `send`/`publish` operation owns the message (and overwrites it), while a `receive`/`subscribe` operation only references it - it is still documented if missing, but never overwrites an entry owned by another service. Existing behaviour is preserved: explicit `x-eventcatalog-role` (`provider`/`client`) still wins, and single-service catalogs are unaffected.

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -485,8 +485,9 @@ export default async (config: any, options: Props) => {
         const isMessageMarkedAsDraft =
           isDomainMarkedAsDraft || isServiceMarkedAsDraft || message.extensions().get('x-eventcatalog-draft')?.value() || null;
 
-        // does this service own or just consume the message?
-        const serviceOwnsMessageContract = isServiceMessageOwner(message, operation);
+        // does this service own, reference, or treat the message as external?
+        const messageOwnership = getMessageOwnership(message, operation);
+        const serviceOwnsMessageContract = messageOwnership === 'owner';
         const isReceived = operation.action() === 'receive' || operation.action() === 'subscribe';
         const isSent = operation.action() === 'send' || operation.action() === 'publish';
 
@@ -530,12 +531,16 @@ export default async (config: any, options: Props) => {
           messagePath = messageId;
         }
 
-        if (serviceOwnsMessageContract) {
+        if (messageOwnership === 'external') {
+          // Explicit `x-eventcatalog-role: client` - the message is owned by another service,
+          // therefore we don't need to document it.
+          console.log(chalk.yellow(` - Skipping external message: ${getMessageName(message)}(v${messageVersion})`));
+        } else {
           // Check if the message already exists in the catalog
           const catalogedMessage = await getMessage(messageId, 'latest');
           let shouldWriteMessage = true;
 
-          if (catalogedMessage) {
+          if (serviceOwnsMessageContract && catalogedMessage) {
             // persist markdown, badges and attachments if it exists
             messageMarkdown = catalogedMessage.markdown;
             messageBadges = catalogedMessage.badges || null;
@@ -560,6 +565,14 @@ export default async (config: any, options: Props) => {
               messageVersion = catalogedVersion;
               shouldWriteMessage = false;
             }
+          } else if (!serviceOwnsMessageContract && catalogedMessage) {
+            // Reference (e.g. a `receive` operation with no explicit role): the owning service has
+            // already documented this message - reference its existing version without overwriting it.
+            console.log(
+              chalk.yellow(` - Referencing existing message ${messageId} (v${catalogedMessage.version}) without overwriting`)
+            );
+            messageVersion = catalogedMessage.version ?? messageVersion;
+            shouldWriteMessage = false;
           }
 
           if (shouldWriteMessage) {
@@ -581,7 +594,8 @@ export default async (config: any, options: Props) => {
                 ...(isMessageMarkedAsDraft && { draft: true }),
               },
               {
-                override: true,
+                // Only owners overwrite an existing entry; references create the message if missing.
+                override: serviceOwnsMessageContract,
                 path: messagePath,
               }
             );
@@ -625,9 +639,6 @@ export default async (config: any, options: Props) => {
               }
             }
           }
-        } else {
-          // Message is not owned by this service, therefore we don't need to document it
-          console.log(chalk.yellow(` - Skipping external message: ${getMessageName(message)}(v${messageVersion})`));
         }
         // Derive group from x-eventcatalog-group extension if groupMessagesBy is configured
         const group =
@@ -835,19 +846,38 @@ const isJSONSchemaMessage = (message: MessageInterface) => {
   return getSchemaFileName(message).endsWith('.json');
 };
 /**
- * Is the AsyncAPI specification (service) the owner of the message?
- * This is determined by the 'x-eventcatalog-role' extension in the message
+ * How does this service relate to the message?
  *
- * @param message
- * @returns boolean
+ * - `owner`: the service owns the message contract and writes it (overriding any existing entry).
+ * - `reference`: the service uses the message but does not own it. It is documented if missing,
+ *    but an existing entry from the owning service is never overwritten.
+ * - `external`: the message is owned elsewhere and is not documented by this service at all.
  *
- * default is provider (AsyncAPI file / service owns the message)
+ * An explicit 'x-eventcatalog-role' extension (operation- or message-level) always wins and
+ * preserves the original behaviour: `provider` => owner, anything else (e.g. `client`) => external.
+ *
+ * Without an explicit role, ownership follows the operation action: `send`/`publish` owns the
+ * message, while `receive`/`subscribe` only references it (the publisher owns the contract).
  */
-const isServiceMessageOwner = (message: MessageInterface, operation?: { extensions: () => any }): boolean => {
-  // Prefer operation-level override to support shared/ref'ed messages where ownership
+type MessageOwnership = 'owner' | 'reference' | 'external';
+
+const getMessageOwnership = (
+  message: MessageInterface,
+  operation?: { extensions: () => any; action?: () => string }
+): MessageOwnership => {
+  // Prefer an explicit role override to support shared/ref'ed messages where ownership
   // needs to be set per operation/service.
   const operationRole = operation?.extensions?.().get?.('x-eventcatalog-role')?.value?.();
   const messageRole = message.extensions().get('x-eventcatalog-role')?.value();
-  const value = operationRole || messageRole || 'provider';
-  return value === 'provider';
+  const explicitRole = operationRole || messageRole;
+  if (explicitRole) {
+    return explicitRole === 'provider' ? 'owner' : 'external';
+  }
+
+  // No explicit role: ownership follows the operation action.
+  const action = operation?.action?.();
+  if (action === 'receive' || action === 'subscribe') {
+    return 'reference';
+  }
+  return 'owner';
 };

--- a/packages/generator-asyncapi/src/test/asyncapi-files/ownership-publisher.asyncapi.yml
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/ownership-publisher.asyncapi.yml
@@ -1,0 +1,29 @@
+asyncapi: 3.0.0
+info:
+  title: Order Service
+  version: 1.0.0
+  description: Publishes OrderPlaced
+channels:
+  orders:
+    address: orders
+    messages:
+      OrderPlaced:
+        $ref: '#/components/messages/OrderPlaced'
+operations:
+  sendOrderPlaced:
+    action: send
+    channel:
+      $ref: '#/channels/orders'
+    messages:
+      - $ref: '#/channels/orders/messages/OrderPlaced'
+components:
+  messages:
+    OrderPlaced:
+      summary: Owned by the order service
+      payload:
+        type: object
+        properties:
+          orderId:
+            type: string
+          amount:
+            type: number

--- a/packages/generator-asyncapi/src/test/asyncapi-files/ownership-subscriber.asyncapi.yml
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/ownership-subscriber.asyncapi.yml
@@ -1,0 +1,27 @@
+asyncapi: 3.0.0
+info:
+  title: Notification Service
+  version: 1.0.0
+  description: Subscribes to OrderPlaced
+channels:
+  orders:
+    address: orders
+    messages:
+      OrderPlaced:
+        $ref: '#/components/messages/OrderPlaced'
+operations:
+  receiveOrderPlaced:
+    action: receive
+    channel:
+      $ref: '#/channels/orders'
+    messages:
+      - $ref: '#/channels/orders/messages/OrderPlaced'
+components:
+  messages:
+    OrderPlaced:
+      summary: Subscriber's view of the message
+      payload:
+        type: object
+        properties:
+          orderId:
+            type: string

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -1472,6 +1472,44 @@ describe('AsyncAPI EventCatalog Plugin', () => {
       expect(service.receives).toContainEqual({ id: 'UserSignedUp', version: '1.0.0' });
     });
 
+    it('without an explicit role, a `receive` operation still documents the message when no other service owns it (non-breaking)', async () => {
+      const { getEvent, getService } = utils(catalogDir);
+
+      await plugin(config, {
+        services: [{ path: join(asyncAPIExamplesDir, 'ownership-subscriber.asyncapi.yml'), id: 'notification-service' }],
+      });
+
+      // Received message is still documented if nothing else owns it yet
+      const event = await getEvent('OrderPlaced', 'latest');
+      expect(event).toBeDefined();
+      expect(event.summary).toEqual("Subscriber's view of the message");
+
+      const service = await getService('notification-service', '1.0.0');
+      expect(service.receives).toContainEqual({ id: 'OrderPlaced', version: '1.0.0' });
+    });
+
+    it('without an explicit role, a `receive` operation references the owner`s message without overwriting it', async () => {
+      const { getEvent, getService } = utils(catalogDir);
+
+      // The sending service owns the message
+      await plugin(config, {
+        services: [{ path: join(asyncAPIExamplesDir, 'ownership-publisher.asyncapi.yml'), id: 'order-service' }],
+      });
+
+      // The receiving service references it - it must not overwrite the owner's contract
+      await plugin(config, {
+        services: [{ path: join(asyncAPIExamplesDir, 'ownership-subscriber.asyncapi.yml'), id: 'notification-service' }],
+      });
+
+      const event = await getEvent('OrderPlaced', 'latest');
+      expect(event.summary).toEqual('Owned by the order service');
+
+      const orderService = await getService('order-service', '1.0.0');
+      const notificationService = await getService('notification-service', '1.0.0');
+      expect(orderService.sends).toContainEqual({ id: 'OrderPlaced', version: '1.0.0' });
+      expect(notificationService.receives).toContainEqual({ id: 'OrderPlaced', version: '1.0.0' });
+    });
+
     it('when the `x-eventcatalog-message-version` is defined on a message that version is used and not the the AsyncAPI version', async () => {
       const { getEvent } = utils(catalogDir);
       const { getService } = utils(catalogDir);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

EventCatalog models a message as a single shared contract, but the AsyncAPI generator treated every service as the owner of every message it referenced, so whichever service was generated last would overwrite the message's catalog entry — letting a subscriber clobber the publisher's summary, schema, and badges. AsyncAPI already expresses producer/consumer intent through the operation action (send vs receive), so we now use that signal to decide ownership: senders own and may overwrite the contract, while receivers only reference it. This keeps the published contract authoritative and stable regardless of generation order, without breaking existing setups — explicit x-eventcatalog-role still wins and single-service catalogs are unaffected.
