### PR TITLE
Support OpenAPI 3.1.2 specifications

### DIFF
--- a/.changeset/fuzzy-pets-swim.md
+++ b/.changeset/fuzzy-pets-swim.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/generator-openapi': patch
+---
+
+Support OpenAPI 3.1.2 specifications by updating the Swagger Parser dependency.

--- a/packages/generator-openapi/package.json
+++ b/packages/generator-openapi/package.json
@@ -35,7 +35,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@apidevtools/swagger-parser": "^10.1.0",
+    "@apidevtools/swagger-parser": "^12.1.0",
     "@changesets/cli": "^2.27.7",
     "@eventcatalog/sdk": "^2.18.4",
     "chalk": "4.1.2",

--- a/packages/generator-openapi/src/test/openapi-files/openapi-3-1-2.yml
+++ b/packages/generator-openapi/src/test/openapi-files/openapi-3-1-2.yml
@@ -1,0 +1,23 @@
+openapi: 3.1.2
+info:
+  title: OpenAPI 3.1.2 Pets API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List pets
+      responses:
+        '200':
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -286,6 +286,30 @@ describe('OpenAPI EventCatalog Plugin', () => {
         );
       });
 
+      it('OpenAPI 3.1.2 specs are mapped into a service in EventCatalog', async () => {
+        const { getService, getQuery } = utils(catalogDir);
+
+        await plugin(config, { services: [{ path: join(openAPIExamples, 'openapi-3-1-2.yml'), id: 'openapi-3-1-2' }] });
+
+        const service = await getService('openapi-3-1-2', '1.0.0');
+        const query = await getQuery('listPets', '1.0.0');
+
+        expect(service).toEqual(
+          expect.objectContaining({
+            id: 'openapi-3-1-2',
+            name: 'OpenAPI 3.1.2 Pets API',
+            version: '1.0.0',
+            schemaPath: 'openapi-3-1-2.yml',
+          })
+        );
+        expect(query).toEqual(
+          expect.objectContaining({
+            id: 'listPets',
+            version: '1.0.0',
+          })
+        );
+      });
+
       it('when the OpenaPI service is already defined in EventCatalog and the versions match, only metadata is updated', async () => {
         // Create a service with the same name and version as the OpenAPI file for testing
         const { writeService, getService } = utils(catalogDir);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,8 +512,8 @@ importers:
   packages/generator-openapi:
     dependencies:
       '@apidevtools/swagger-parser':
-        specifier: ^10.1.0
-        version: 10.1.1(openapi-types@12.1.3)
+        specifier: ^12.1.0
+        version: 12.1.0(openapi-types@12.1.3)
       '@changesets/cli':
         specifier: ^2.27.7
         version: 2.29.5
@@ -572,6 +572,10 @@ packages:
     resolution: { integrity: sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA== }
     engines: { node: '>= 16' }
 
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    resolution: { integrity: sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw== }
+    engines: { node: '>= 16' }
+
   '@apidevtools/openapi-schemas@2.1.0':
     resolution: { integrity: sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ== }
     engines: { node: '>=10' }
@@ -581,6 +585,11 @@ packages:
 
   '@apidevtools/swagger-parser@10.1.1':
     resolution: { integrity: sha512-u/kozRnsPO/x8QtKYJOqoGtC4kH6yg1lfYkB9Au0WhYB0FNLpyFusttQtvhlwjtG3rOwiRz4D8DnnXa8iEpIKA== }
+    peerDependencies:
+      openapi-types: '>=7'
+
+  '@apidevtools/swagger-parser@12.1.0':
+    resolution: { integrity: sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng== }
     peerDependencies:
       openapi-types: '>=7'
 
@@ -4244,6 +4253,11 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.0
 
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.1
+
   '@apidevtools/openapi-schemas@2.1.0': {}
 
   '@apidevtools/swagger-methods@3.0.2': {}
@@ -4254,6 +4268,16 @@ snapshots:
       '@apidevtools/openapi-schemas': 2.1.0
       '@apidevtools/swagger-methods': 3.0.2
       '@jsdevtools/ono': 7.1.3
+      ajv: 8.17.1
+      ajv-draft-04: 1.0.0(ajv@8.17.1)
+      call-me-maybe: 1.0.2
+      openapi-types: 12.1.3
+
+  '@apidevtools/swagger-parser@12.1.0(openapi-types@12.1.3)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 14.0.1
+      '@apidevtools/openapi-schemas': 2.1.0
+      '@apidevtools/swagger-methods': 3.0.2
       ajv: 8.17.1
       ajv-draft-04: 1.0.0(ajv@8.17.1)
       call-me-maybe: 1.0.2


### PR DESCRIPTION
## What This PR Does

Adds support for OpenAPI 3.1.2 specifications in the OpenAPI generator. The previous version of `@apidevtools/swagger-parser` (v10) did not fully support 3.1.2 specs, so this PR bumps the dependency to v12 and adds a regression test plus a fixture to confirm 3.1.2 specs are parsed and mapped into EventCatalog correctly.

## Changes Overview

### Key Changes

- Bump `@apidevtools/swagger-parser` from `^10.1.0` to `^12.1.0` in `generator-openapi`
- Add a new test fixture `openapi-3-1-2.yml`
- Add a test verifying an OpenAPI 3.1.2 spec is mapped into a service and its operations (queries) in EventCatalog
- Update `pnpm-lock.yaml` to reflect the new dependency tree

## How It Works

`@apidevtools/swagger-parser` v12 pulls in a newer `json-schema-ref-parser` (v14) that handles OpenAPI 3.1.x schemas correctly. The generator continues to call the parser the same way; the upgrade transparently enables 3.1.2 support. The added test loads the new fixture through the plugin and asserts that the service (`openapi-3-1-2`) and an operation (`listPets`) are created with the expected metadata.

## Breaking Changes

None.

## Additional Notes

The dependency bump is a major version of the parser, but it is an internal dependency of the generator with no API changes affecting consumers — hence shipped as a patch.