### PR TITLE
Allow OpenAPI 3.1 info.license with name only

### DIFF
--- a/.changeset/quiet-spiders-cheer.md
+++ b/.changeset/quiet-spiders-cheer.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/generator-openapi': patch
+---
+
+Allow OpenAPI 3.1 specs with an `info.license` object that only defines a `name` (no `url` or `identifier`), which is valid per the OpenAPI 3.1 spec but was previously rejected during validation.

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -2,12 +2,11 @@ import utils from '@eventcatalog/sdk';
 import { readFile } from 'node:fs/promises';
 import fs from 'node:fs/promises';
 import chalk from 'chalk';
-import SwaggerParser from '@apidevtools/swagger-parser';
 
 import { defaultMarkdown as generateMarkdownForDomain } from './utils/domains';
 import { buildService, getSummary } from './utils/services';
 import { buildMessage } from './utils/messages';
-import { getOperationsByType, getExamplesByOperationId } from './utils/openapi';
+import { getOperationsByType, getExamplesByOperationId, validateAndDereferenceOpenAPI } from './utils/openapi';
 import { Domain, Service, Message, Operation, Pointer } from './types';
 import { getMessageTypeUtils } from './utils/catalog-shorthand';
 import { OpenAPI } from 'openapi-types';
@@ -212,11 +211,9 @@ export default async (_: any, options: Props) => {
         // If URL with headers, fetch and parse in memory
         if (isUrl && hasHeaders) {
           const parsedSpec = await fetchAuthenticatedSpec(specFile, serviceSpec.headers!);
-          await SwaggerParser.validate(parsedSpec);
-          document = await SwaggerParser.dereference(parsedSpec);
+          document = (await validateAndDereferenceOpenAPI(parsedSpec)) as OpenAPI.Document;
         } else {
-          await SwaggerParser.validate(specFile);
-          document = await SwaggerParser.dereference(specFile);
+          document = (await validateAndDereferenceOpenAPI(specFile)) as OpenAPI.Document;
         }
 
         return {

--- a/packages/generator-openapi/src/test/openapi-files/openapi-3-1-license-name-only.json
+++ b/packages/generator-openapi/src/test/openapi-files/openapi-3-1-license-name-only.json
@@ -1,0 +1,177 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": ["pets"],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paged array of pets",
+            "headers": {
+              "x-next": {
+                "description": "A link to the next page of responses",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pets"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": ["pets"],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": ["pets"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Pets": {
+        "type": "array",
+        "maxItems": 100,
+        "items": {
+          "$ref": "#/components/schemas/Pet"
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": ["code", "message"],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -310,6 +310,29 @@ describe('OpenAPI EventCatalog Plugin', () => {
         );
       });
 
+      it('OpenAPI 3.1.0 specs allow info.license with only a name', async () => {
+        const { getService, getQuery, getCommand } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [{ path: join(openAPIExamples, 'openapi-3-1-license-name-only.json'), id: 'openapi-3-1-license-name-only' }],
+        });
+
+        const service = await getService('openapi-3-1-license-name-only', '1.0.0');
+        const listPets = await getQuery('listPets', '1.0.0');
+        const createPets = await getCommand('createPets', '1.0.0');
+
+        expect(service).toEqual(
+          expect.objectContaining({
+            id: 'openapi-3-1-license-name-only',
+            name: 'Swagger Petstore',
+            version: '1.0.0',
+            schemaPath: 'openapi-3-1-license-name-only.json',
+          })
+        );
+        expect(listPets).toEqual(expect.objectContaining({ id: 'listPets', version: '1.0.0' }));
+        expect(createPets).toEqual(expect.objectContaining({ id: 'createPets', version: '1.0.0' }));
+      });
+
       it('when the OpenaPI service is already defined in EventCatalog and the versions match, only metadata is updated', async () => {
         // Create a service with the same name and version as the OpenAPI file for testing
         const { writeService, getService } = utils(catalogDir);

--- a/packages/generator-openapi/src/utils/openapi.ts
+++ b/packages/generator-openapi/src/utils/openapi.ts
@@ -3,6 +3,45 @@ import { OpenAPIDocument, OpenAPIOperation, OpenAPIParameter, Operation } from '
 import { HTTP_METHOD, HTTP_METHOD_TO_MESSAGE_TYPE } from '../index';
 const DEFAULT_MESSAGE_TYPE = 'query';
 
+const getErrorMessage = (error: unknown) => (error instanceof Error ? error.message : String(error));
+
+const isOpenAPI31LicenseNameOnly = (api: any) => {
+  const license = api?.info?.license;
+
+  return (
+    typeof api?.openapi === 'string' &&
+    api.openapi.startsWith('3.1.') &&
+    license &&
+    typeof license.name === 'string' &&
+    !license.identifier &&
+    !license.url
+  );
+};
+
+const isLicenseNameOnlyValidationError = (error: unknown) => {
+  const message = getErrorMessage(error);
+
+  return (
+    message.includes('#/info/license') &&
+    message.includes("must have required property 'identifier'") &&
+    message.includes("must have required property 'url'") &&
+    message.includes('must match exactly one schema in oneOf')
+  );
+};
+
+export async function validateAndDereferenceOpenAPI(api: string | any) {
+  try {
+    await SwaggerParser.validate(api);
+  } catch (error) {
+    const parsed = await SwaggerParser.parse(api);
+    if (!isLicenseNameOnlyValidationError(error) || !isOpenAPI31LicenseNameOnly(parsed)) {
+      throw error;
+    }
+  }
+
+  return SwaggerParser.dereference(api);
+}
+
 export async function getSchemasByOperationId(
   filePath: string,
   operationId: string | undefined,
@@ -168,7 +207,7 @@ export async function getOperationsByType(
 ) {
   try {
     // Use pre-parsed document if provided, otherwise parse from file
-    const api = parsedDocument || (await SwaggerParser.validate(openApiPath));
+    const api = parsedDocument || (await validateAndDereferenceOpenAPI(openApiPath));
 
     const operations = [];
 


### PR DESCRIPTION
Closes #413

## What This PR Does

OpenAPI 3.1 specs may define `info.license` with just a `name` and no `url` or `identifier`, which is valid per the [OpenAPI 3.1 License Object spec](https://spec.openapis.org/oas/v3.1.0#license-object). The underlying `@apidevtools/swagger-parser` validator incorrectly rejected these specs with a `oneOf` schema error. This PR makes the OpenAPI generator tolerate this specific, valid case while still surfacing all other validation errors.

## Changes Overview

### Key Changes

- Add a `validateAndDereferenceOpenAPI` helper in `utils/openapi.ts` that validates, and on failure, only swallows the error when it is the known false-positive `info.license` name-only validation error against a genuine OpenAPI 3.1 spec.
- Route both spec-loading paths in `index.ts` (authenticated URL fetch and file/URL) through the new helper, replacing the inline `SwaggerParser.validate` + `dereference` calls.
- Use the helper inside `getOperationsByType` as well.
- Add a test fixture (`openapi-3-1-license-name-only.json`) and a test asserting the service and operations generate correctly.

## How It Works

`validateAndDereferenceOpenAPI` runs `SwaggerParser.validate` first. If it throws, the error message is checked against the precise signature of the license `oneOf` failure (`#/info/license`, missing `identifier`, missing `url`, `must match exactly one schema in oneOf`) and the parsed document is checked to confirm it is a `3.1.x` spec whose `info.license` truly has only a `name`. Only when both conditions hold is the error suppressed; otherwise it is re-thrown unchanged. Dereferencing then proceeds as before.

## Breaking Changes

None.

## Additional Notes

The suppression is intentionally narrow — it matches the exact error signature and re-verifies the document shape, so unrelated validation failures (including other license misconfigurations) continue to throw.