### PR TITLE
Respect `setMessageOwnersToServiceOwners` option in OpenAPI generator

### DIFF
--- a/.changeset/quiet-otters-jump.md
+++ b/.changeset/quiet-otters-jump.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/generator-openapi': patch
+---
+
+Fix `setMessageOwnersToServiceOwners` option being ignored and leaking as a service property. The option now correctly defaults to `true`, respects `false` to prevent service owners being applied to messages, and is no longer written onto the generated service. Resolves https://github.com/event-catalog/eventcatalog/issues/2721

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -247,6 +247,7 @@ export default async (_: any, options: Props) => {
         document,
         serviceSpec.generateMarkdown
       );
+      const setMessageOwnersToServiceOwners = serviceSpec.setMessageOwnersToServiceOwners ?? true;
 
       let serviceMarkdown = service.markdown;
       let serviceSpecificationsFiles: Array<{ fileName: string; content: string }> = [];
@@ -349,7 +350,7 @@ export default async (_: any, options: Props) => {
       // Process all messages for the OpenAPI spec
       let { sends, receives, allGeneratedMessages } = await processMessagesForOpenAPISpec(specPath, document, servicePath, {
         ...options,
-        owners: service.setMessageOwnersToServiceOwners ? service.owners : [],
+        owners: setMessageOwnersToServiceOwners ? service.owners : [],
         serviceHasMultipleSpecFiles: Array.isArray(serviceSpec.path),
         isDraft: isServiceMarkedAsDraft,
         serviceId: service.id,

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -1109,12 +1109,20 @@ describe('OpenAPI EventCatalog Plugin', () => {
         const { getService } = utils(catalogDir);
 
         await plugin(config, {
-          services: [{ path: join(openAPIExamples, 'petstore.yml'), id: 'swagger-petstore', owners: ['John Doe', 'Jane Doe'] }],
+          services: [
+            {
+              path: join(openAPIExamples, 'petstore.yml'),
+              id: 'swagger-petstore',
+              owners: ['John Doe', 'Jane Doe'],
+              setMessageOwnersToServiceOwners: true,
+            },
+          ],
         });
 
         const service = await getService('swagger-petstore', '1.0.0');
 
         expect(service.owners).toEqual(['John Doe', 'Jane Doe']);
+        expect(service).not.toHaveProperty('setMessageOwnersToServiceOwners');
       });
 
       it('if the service has `x-eventcatalog-draft` header set to true, the service is added as `draft` and all the messages are added as `draft`', async () => {
@@ -1630,6 +1638,25 @@ describe('OpenAPI EventCatalog Plugin', () => {
         expect(getCommandMessage).toBeDefined();
         expect(getCommandByProductId.owners).toEqual(['John Doe', 'Jane Doe']);
         expect(getCommandMessage.owners).toEqual(['John Doe', 'Jane Doe']);
+      });
+
+      it('when setMessageOwnersToServiceOwners is false, service owners are not added to messages', async () => {
+        const { getCommand } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [
+            {
+              path: join(openAPIExamples, 'without-operationIds.yml'),
+              id: 'product-api',
+              owners: ['John Doe', 'Jane Doe'],
+              setMessageOwnersToServiceOwners: false,
+            },
+          ],
+        });
+
+        const getCommandMessage = await getCommand('product-api_GET');
+
+        expect(getCommandMessage.owners).toEqual([]);
       });
 
       it('when the message has been marked as deprecated (with x-eventcatalog-deprecated-date and x-eventcatalog-deprecated-message), the message is marked as deprecated in EventCatalog', async () => {

--- a/packages/generator-openapi/src/utils/services.ts
+++ b/packages/generator-openapi/src/utils/services.ts
@@ -51,7 +51,6 @@ export const buildService = (
       : generatedMarkdownForService,
     badges: documentTags.map((tag) => ({ content: tag.name, textColor: 'blue', backgroundColor: 'blue' })),
     owners: serviceOptions.owners || [],
-    setMessageOwnersToServiceOwners: serviceOptions.setMessageOwnersToServiceOwners || true,
     writesTo: serviceOptions.writesTo || [],
     readsFrom: serviceOptions.readsFrom || [],
   };


### PR DESCRIPTION
Resolves https://github.com/event-catalog/eventcatalog/issues/2721

## What This PR Does

Fixes the `setMessageOwnersToServiceOwners` service option in the OpenAPI generator. The option was effectively ignored (always evaluating to `true`) and was also being written onto the generated service object as an unexpected property. It now defaults to `true`, correctly honours `false`, and no longer leaks into the service.

## Changes Overview

### Key Changes

- Stop writing `setMessageOwnersToServiceOwners` onto the built service object in `utils/services.ts` (the `|| true` fallback made it always `true`).
- Read the option in `index.ts` with a proper `?? true` default and use it to decide whether service owners are applied to messages.
- Add test coverage: the option no longer appears as a service property, and when set to `false`, service owners are not added to messages.

## How It Works

Previously `buildService` set `setMessageOwnersToServiceOwners: serviceOptions.setMessageOwnersToServiceOwners || true`, which always resolved to `true` and persisted the flag on the service. The generator then read it back off the service. The logic now resolves the option once in `index.ts` (`serviceSpec.setMessageOwnersToServiceOwners ?? true`) and passes the resulting owners list to message processing, keeping the flag out of the service model entirely.

## Breaking Changes

None.

## Additional Notes

Tests were not run as part of this change per request.