### PR TITLE
OpenAPI generator attaches multiple spec files to a single service version

### DIFF
--- a/.changeset/brave-otters-march.md
+++ b/.changeset/brave-otters-march.md
@@ -1,0 +1,12 @@
+---
+'@eventcatalog/generator-openapi': major
+---
+
+feat(openapi): multiple OpenAPI files now attach to a single service version
+
+Breaking change to how multiple OpenAPI files map to service versions:
+
+- When a service entry has multiple `path` values, all specifications are now attached to one service version instead of each spec file creating its own historical service version.
+- When no `version` is configured, the service version is inferred from the highest OpenAPI `info.version` (semver-aware ordering).
+- Previous specification files are now preserved when multiple paths target the same service version, while OpenAPI specs from older service versions stay with the version that produced them.
+- To create separate service version records, configure separate `services` entries with explicit `version` values.

--- a/packages/generator-openapi/src/index.ts
+++ b/packages/generator-openapi/src/index.ts
@@ -219,7 +219,7 @@ export default async (_: any, options: Props) => {
         return {
           document,
           path: specFile,
-          version: serviceSpec.version || document.info.version,
+          version: document.info.version,
         };
       } catch (error) {
         console.error(chalk.red(`Failed to parse OpenAPI file: ${specFile}`));
@@ -231,19 +231,24 @@ export default async (_: any, options: Props) => {
     const validSpecs = await Promise.all(specs);
     const validSpecFiles = validSpecs.filter((v) => v !== null);
 
-    const orderedSpecs = validSpecFiles.sort((a, b) => {
-      const versionA = a?.version ?? '';
-      const versionB = b?.version ?? '';
-      return versionA.localeCompare(versionB);
-    });
+    if (validSpecFiles.length === 0) continue;
 
-    for (const specification of orderedSpecs) {
+    // One service configuration entry represents one service version. When the
+    // version is omitted, infer it from the newest OpenAPI document while keeping
+    // every configured path as a specification of that service version.
+    const inferredServiceVersion = validSpecFiles.reduce(
+      (latest, specification) => (isNewerVersion(specification.version, latest) ? specification.version : latest),
+      validSpecFiles[0].version
+    );
+    const serviceVersion = serviceSpec.version || inferredServiceVersion;
+
+    for (const specification of validSpecFiles) {
       const document = specification.document;
-      const version = specification.version;
+      const version = serviceVersion;
       const specPath = specification.path;
 
       const service = buildService(
-        { ...serviceSpec, path: specPath, version: specification.version },
+        { ...serviceSpec, path: specPath, version: serviceVersion },
         document,
         serviceSpec.generateMarkdown
       );
@@ -366,13 +371,8 @@ export default async (_: any, options: Props) => {
       let serviceWritesTo = configuredWritesTo;
       let serviceReadsFrom = configuredReadsFrom;
 
-      // for now, if the user is doing multiple files into the same service,
-      // we don't persist the previous specification files. TODO: fix this
-      const persistPreviousSpecificationFiles = Array.isArray(serviceSpec.path) === false;
-
       if (latestServiceInCatalog) {
         serviceMarkdown = latestServiceInCatalog.markdown;
-        serviceSpecificationsFiles = await getExistingSpecificationFiles(service.id, latestServiceInCatalog.specifications);
         // Merge fresh sends (carrying current `group` values derived from groupMessagesBy)
         // with any catalog-only pointers, preferring the fresh ones on id+version collisions.
         sends = mergePointersPreferringFresh(sends, latestServiceInCatalog.sends || []);
@@ -386,13 +386,16 @@ export default async (_: any, options: Props) => {
         serviceEntities = latestServiceInCatalog.entities || null;
         serviceWritesTo = latestServiceInCatalog.writesTo || ([] as any);
         serviceReadsFrom = latestServiceInCatalog.readsFrom || ([] as any);
-        // persist any specifications that are already in the catalog,
-        // while adding newly generated OpenAPI specs without losing existing AsyncAPI/GraphQL specs
-        if (persistPreviousSpecificationFiles) {
-          serviceSpecifications = mergeSpecifications(latestServiceInCatalog.specifications, serviceSpecifications, {
-            preferArray: true,
-          });
-        }
+        // Specifications accumulate when multiple paths target the same service
+        // version. Across service versions, preserve non-OpenAPI specifications,
+        // but keep each generated OpenAPI contract with the version that produced it.
+        const specificationsToPreserve = isSameVersion(latestServiceInCatalog.version, version)
+          ? latestServiceInCatalog.specifications
+          : toSpecificationEntries(latestServiceInCatalog.specifications).filter((spec) => spec.type !== 'openapi');
+        serviceSpecificationsFiles = await getExistingSpecificationFiles(service.id, specificationsToPreserve);
+        serviceSpecifications = mergeSpecifications(specificationsToPreserve, serviceSpecifications, {
+          preferArray: true,
+        });
 
         // Match found, override it
         if (latestServiceInCatalog.version === version) {
@@ -437,7 +440,7 @@ export default async (_: any, options: Props) => {
       // What files need added to the service (specification files)
       const specFiles = [
         // add any previous spec files to the list
-        ...(persistPreviousSpecificationFiles ? serviceSpecificationsFiles : []),
+        ...serviceSpecificationsFiles,
         {
           content: saveParsedSpecFile
             ? getParsedSpecFile({ ...serviceSpec, path: specPath }, document)

--- a/packages/generator-openapi/src/test/openapi-files/petstore-v10-no-extensions.yml
+++ b/packages/generator-openapi/src/test/openapi-files/petstore-v10-no-extensions.yml
@@ -1,0 +1,8 @@
+openapi: '3.0.0'
+info:
+  version: 10.0.0
+  title: Swagger Petstore
+  description: This is a sample server Petstore server.
+  license:
+    name: MIT
+paths: {}

--- a/packages/generator-openapi/src/test/plugin.test.ts
+++ b/packages/generator-openapi/src/test/plugin.test.ts
@@ -2411,8 +2411,214 @@ describe('OpenAPI EventCatalog Plugin', () => {
       });
     });
 
-    describe('parsing multiple OpenAPI files to the same service', () => {
-      it('when multiple OpenAPI files are parsed to the same service, the services and messages are written to the correct locations', async () => {
+    describe('service and specification versioning patterns', () => {
+      it('Pattern 1 — a single specification without a configured service version uses its OpenAPI version', async () => {
+        // Pattern:
+        // A service has one OpenAPI specification and does not configure `version`.
+        // The OpenAPI document's `info.version` becomes the EventCatalog service version.
+        const { getService } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [
+            {
+              path: join(openAPIExamples, 'petstore-v1-no-extensions.yml'),
+              id: 'single-specification-service',
+            },
+          ],
+        });
+
+        const service = await getService('single-specification-service', '1.0.0');
+
+        expect(service).toEqual(
+          expect.objectContaining({
+            id: 'single-specification-service',
+            version: '1.0.0',
+            specifications: [{ type: 'openapi', path: 'petstore-v1-no-extensions.yml', name: 'Swagger Petstore' }],
+          })
+        );
+      });
+
+      it('Pattern 2 — multiple specifications with a configured service version are attached to that one version', async () => {
+        // Pattern:
+        // A service explicitly owns its lifecycle version and has multiple API contracts.
+        // Every path belongs to the configured service version, regardless of each document's `info.version`.
+        const { getService } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [
+            {
+              path: [
+                join(openAPIExamples, 'petstore-v1-no-extensions.yml'),
+                join(openAPIExamples, 'petstore-v2-no-extensions.yml'),
+              ],
+              id: 'explicit-version-multiple-specifications-service',
+              version: '10.0.0',
+            },
+          ],
+        });
+
+        const service = await getService('explicit-version-multiple-specifications-service', '10.0.0');
+
+        expect(service).toEqual(
+          expect.objectContaining({
+            id: 'explicit-version-multiple-specifications-service',
+            version: '10.0.0',
+            specifications: [
+              { type: 'openapi', path: 'petstore-v1-no-extensions.yml', name: 'Swagger Petstore' },
+              { type: 'openapi', path: 'petstore-v2-no-extensions.yml', name: 'Swagger Petstore' },
+            ],
+          })
+        );
+        expect(existsSync(join(catalogDir, 'services', service.id, 'petstore-v1-no-extensions.yml'))).toBe(true);
+        expect(existsSync(join(catalogDir, 'services', service.id, 'petstore-v2-no-extensions.yml'))).toBe(true);
+      });
+
+      it('Pattern 3 — multiple specifications without a configured service version use the latest OpenAPI version', async () => {
+        // Pattern:
+        // A service has multiple API contracts but does not explicitly own a lifecycle version.
+        // The highest OpenAPI `info.version` becomes the service version and all contracts are attached to it;
+        // specifications in one path array do not independently create historical service records.
+        const { getService } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [
+            {
+              path: [
+                join(openAPIExamples, 'petstore-v1-no-extensions.yml'),
+                join(openAPIExamples, 'petstore-v2-no-extensions.yml'),
+              ],
+              id: 'inferred-version-multiple-specifications-service',
+            },
+          ],
+        });
+
+        const service = await getService('inferred-version-multiple-specifications-service', '2.0.0');
+        const historicalService = await getService('inferred-version-multiple-specifications-service', '1.0.0');
+
+        expect(service).toEqual(
+          expect.objectContaining({
+            id: 'inferred-version-multiple-specifications-service',
+            version: '2.0.0',
+            specifications: [
+              { type: 'openapi', path: 'petstore-v1-no-extensions.yml', name: 'Swagger Petstore' },
+              { type: 'openapi', path: 'petstore-v2-no-extensions.yml', name: 'Swagger Petstore' },
+            ],
+          })
+        );
+        expect(historicalService).toBeUndefined();
+        expect(existsSync(join(catalogDir, 'services', service.id, 'petstore-v1-no-extensions.yml'))).toBe(true);
+        expect(existsSync(join(catalogDir, 'services', service.id, 'petstore-v2-no-extensions.yml'))).toBe(true);
+      });
+
+      it('Pattern 3b — the latest OpenAPI version is selected using semantic version ordering', async () => {
+        // Pattern:
+        // A service has specifications with versions that sort differently as strings and as semantic versions.
+        // Version 10.0.0 is newer than 2.0.0, so it becomes the inferred service version.
+        const { getService } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [
+            {
+              path: [
+                join(openAPIExamples, 'petstore-v2-no-extensions.yml'),
+                join(openAPIExamples, 'petstore-v10-no-extensions.yml'),
+              ],
+              id: 'semantically-ordered-inferred-version-service',
+            },
+          ],
+        });
+
+        const service = await getService('semantically-ordered-inferred-version-service', 'latest');
+
+        expect(service.version).toBe('10.0.0');
+      });
+
+      it('Pattern 4 — separate entries with explicit versions create separate service version records', async () => {
+        // Pattern:
+        // Each `services` entry represents one version of a service. A newer entry versions the older record,
+        // and specifications remain attached only to the service version declared by their entry.
+        const { getService } = utils(catalogDir);
+
+        await plugin(config, {
+          services: [
+            {
+              path: join(openAPIExamples, 'petstore-v1-no-extensions.yml'),
+              id: 'explicit-service-version-history',
+              version: '1.0.0',
+            },
+            {
+              path: join(openAPIExamples, 'petstore-v2-no-extensions.yml'),
+              id: 'explicit-service-version-history',
+              version: '2.0.0',
+            },
+          ],
+        });
+
+        const currentService = await getService('explicit-service-version-history', '2.0.0');
+        const historicalService = await getService('explicit-service-version-history', '1.0.0');
+        const serviceDirectory = join(catalogDir, 'services', 'explicit-service-version-history');
+
+        expect(existsSync(join(serviceDirectory, 'index.mdx'))).toBe(true);
+        expect(existsSync(join(serviceDirectory, 'petstore-v2-no-extensions.yml'))).toBe(true);
+        expect(existsSync(join(serviceDirectory, 'versioned', '1.0.0', 'index.mdx'))).toBe(true);
+        expect(existsSync(join(serviceDirectory, 'versioned', '1.0.0', 'petstore-v1-no-extensions.yml'))).toBe(true);
+        expect(existsSync(join(serviceDirectory, 'petstore-v1-no-extensions.yml'))).toBe(false);
+
+        expect(currentService.specifications).toEqual([
+          { type: 'openapi', path: 'petstore-v2-no-extensions.yml', name: 'Swagger Petstore' },
+        ]);
+        expect(historicalService.specifications).toEqual([
+          { type: 'openapi', path: 'petstore-v1-no-extensions.yml', name: 'Swagger Petstore' },
+        ]);
+      });
+
+      it('Pattern 5 — a newer service version discovered on a later run versions the existing record', async () => {
+        // Pattern:
+        // A catalog already contains a generated service. On a later generator run, a higher version is found.
+        // The previous service and its specification become historical while the new version becomes current.
+        const { getService, writeService, addFileToService } = utils(catalogDir);
+
+        await writeService({
+          id: 'service-updated-across-runs',
+          name: 'Swagger Petstore',
+          version: '1.0.0',
+          schemaPath: 'petstore-v1-no-extensions.yml',
+          specifications: [{ type: 'openapi', path: 'petstore-v1-no-extensions.yml', name: 'Swagger Petstore' }],
+          markdown: '',
+        });
+        await addFileToService(
+          'service-updated-across-runs',
+          {
+            fileName: 'petstore-v1-no-extensions.yml',
+            content: await fs.readFile(join(openAPIExamples, 'petstore-v1-no-extensions.yml'), 'utf8'),
+          },
+          '1.0.0'
+        );
+        expect(await getService('service-updated-across-runs', 'latest')).toBeDefined();
+
+        await plugin(config, {
+          services: [
+            {
+              path: join(openAPIExamples, 'petstore-v2-no-extensions.yml'),
+              id: 'service-updated-across-runs',
+            },
+          ],
+        });
+
+        const currentService = await getService('service-updated-across-runs', '2.0.0');
+        const historicalService = await getService('service-updated-across-runs', '1.0.0');
+
+        expect(currentService.specifications).toEqual([
+          { type: 'openapi', path: 'petstore-v2-no-extensions.yml', name: 'Swagger Petstore' },
+        ]);
+        expect(historicalService.specifications).toEqual([
+          { type: 'openapi', path: 'petstore-v1-no-extensions.yml', name: 'Swagger Petstore' },
+        ]);
+      });
+    });
+
+    describe('attaching multiple OpenAPI files to the same service version', () => {
+      it('writes every specification to the service version inferred from the latest OpenAPI document', async () => {
         const { getService } = utils(catalogDir);
 
         await plugin(config, {
@@ -2431,32 +2637,24 @@ describe('OpenAPI EventCatalog Plugin', () => {
         const service = await getService('swagger-petstore-2', '2.0.0');
 
         expect(service).toBeDefined();
-        expect(previousService).toBeDefined();
-
-        // Expect versioned folder for 1.0.0 and all files are present
-        expect(existsSync(join(catalogDir, 'services', 'swagger-petstore-2', 'versioned', '1.0.0'))).toBe(true);
-        expect(
-          existsSync(join(catalogDir, 'services', 'swagger-petstore-2', 'versioned', '1.0.0', 'petstore-v1-no-extensions.yml'))
-        ).toBe(true);
-
-        expect(
-          existsSync(join(catalogDir, 'services', 'swagger-petstore-2', 'queries', 'createPets', 'versioned', '1.0.0'))
-        ).toBe(true);
-        expect(existsSync(join(catalogDir, 'services', 'swagger-petstore-2', 'versioned', '1.0.0', 'index.mdx'))).toBe(true);
-
-        // Expect 2.0.0 to be the latest version with expected files
+        expect(previousService).toBeUndefined();
+        expect(existsSync(join(catalogDir, 'services', 'swagger-petstore-2', 'versioned', '1.0.0'))).toBe(false);
         expect(existsSync(join(catalogDir, 'services', 'swagger-petstore-2', 'petstore-v2-no-extensions.yml'))).toBe(true);
-        expect(existsSync(join(catalogDir, 'services', 'swagger-petstore-2', 'petstore-v1-no-extensions.yml'))).toBe(false);
+        expect(existsSync(join(catalogDir, 'services', 'swagger-petstore-2', 'petstore-v1-no-extensions.yml'))).toBe(true);
 
         expect(service).toEqual(
           expect.objectContaining({
             id: 'swagger-petstore-2',
             version: '2.0.0',
-            specifications: [{ type: 'openapi', path: 'petstore-v2-no-extensions.yml', name: 'Swagger Petstore' }],
+            specifications: [
+              { type: 'openapi', path: 'petstore-v2-no-extensions.yml', name: 'Swagger Petstore' },
+              { type: 'openapi', path: 'petstore-v1-no-extensions.yml', name: 'Swagger Petstore' },
+            ],
             sends: [],
             receives: [
               { id: 'listPets', version: '2.0.0' },
               { id: 'createPets', version: '2.0.0' },
+              { id: 'showPetById', version: '2.0.0' },
               { id: 'updatePet', version: '2.0.0' },
               { id: 'deletePet', version: '2.0.0' },
               { id: 'petAdopted', version: '2.0.0' },
@@ -2464,27 +2662,9 @@ describe('OpenAPI EventCatalog Plugin', () => {
             ],
           })
         );
-
-        expect(previousService).toEqual(
-          expect.objectContaining({
-            id: 'swagger-petstore-2',
-            version: '1.0.0',
-            specifications: [{ type: 'openapi', path: 'petstore-v1-no-extensions.yml', name: 'Swagger Petstore' }],
-            sends: [],
-            receives: [
-              { id: 'listPets', version: '1.0.0' },
-              { id: 'createPets', version: '1.0.0' },
-              { id: 'showPetById', version: '1.0.0' },
-              { id: 'updatePet', version: '1.0.0' },
-              { id: 'deletePet', version: '1.0.0' },
-              { id: 'petAdopted', version: '1.0.0' },
-              { id: 'petVaccinated', version: '1.0.0' },
-            ],
-          })
-        );
       });
 
-      it('when multiple OpenAPI files are processed, the messages for each spec file are written to the correct locations', async () => {
+      it('writes messages from every specification to the inferred service version without creating implicit history', async () => {
         await plugin(config, {
           services: [
             {
@@ -2509,12 +2689,9 @@ describe('OpenAPI EventCatalog Plugin', () => {
           'updatePet',
         ]);
 
-        const expectedVersionedQueries = ['createPets', 'deletePet', 'listPets', 'updatePet', 'petAdopted', 'petVaccinated'];
-
-        for (const query of expectedVersionedQueries) {
-          expect(existsSync(join(catalogDir, 'services', 'swagger-petstore-2', 'queries', query, 'versioned', '1.0.0'))).toBe(
-            true
-          );
+        for (const query of queries) {
+          expect(existsSync(join(catalogDir, 'services', 'swagger-petstore-2', 'queries', query, 'index.mdx'))).toBe(true);
+          expect(existsSync(join(catalogDir, 'services', 'swagger-petstore-2', 'queries', query, 'versioned'))).toBe(false);
         }
       });
     });


### PR DESCRIPTION

## What This PR Does

Changes how the OpenAPI generator handles a service configured with multiple OpenAPI files. Previously, each spec file created its own service version in the catalog, turning a single `path` array into implicit version history. Now all spec files in one service entry attach to a single service version, and version history is only created when users explicitly configure separate service entries with different versions.

## Changes Overview

### Key Changes

- A service entry with multiple `path` values now produces one service version holding all specifications, instead of one historical service version per spec file.
- When no `version` is configured, the service version is inferred from the highest OpenAPI `info.version` across the spec files, using semver-aware ordering (so `10.0.0` beats `2.0.0`).
- Specification files accumulate on the service when multiple paths target the same service version. Across service versions, non-OpenAPI specifications (AsyncAPI, GraphQL) are preserved, while OpenAPI specs stay with the service version that produced them.
- Removed the previous limitation where spec files were not persisted when using multiple files for the same service (the old `persistPreviousSpecificationFiles` workaround and its TODO).
- Added a test suite documenting the five supported versioning patterns, plus a `petstore-v10-no-extensions.yml` fixture for the semver-ordering case.

## How It Works

Instead of sorting spec files by version and writing each as a separate service version, the generator now:

1. Parses all spec files for a service entry and reads each document's `info.version`.
2. Resolves a single service version: the configured `version` if present, otherwise the highest `info.version` found (using `isNewerVersion` for semver comparison).
3. Writes every specification against that one service version.
4. When merging with an existing catalog service, it preserves all existing specifications if the versions match (accumulating specs), or preserves only non-OpenAPI specifications when the service is being bumped to a new version — so historical OpenAPI contracts remain in their versioned folders.

## Breaking Changes

- **Multiple spec files no longer create implicit service version history.** A service entry with `path: [v1.yml, v2.yml]` and no `version` previously produced a current service (e.g. `2.0.0`) plus a versioned record (e.g. `1.0.0`). It now produces a single service version (`2.0.0`) containing both specification files.
- **Service version inference ignores a configured version mismatch per file.** Each spec file no longer carries its own service version; all files adopt the resolved service version, including their generated messages.
- To keep the old behavior of separate version records, configure separate `services` entries with explicit `version` values (Pattern 4 in the tests).

## Additional Notes

- The new tests in `packages/generator-openapi/src/test/plugin.test.ts` document each supported pattern (single spec, explicit version with multiple specs, inferred version, semver ordering, explicit version history, and version bumps across generator runs).
