### PR TITLE
Derive message ownership from AsyncAPI operation action

### DIFF
--- a/.changeset/asyncapi-action-based-ownership.md
+++ b/.changeset/asyncapi-action-based-ownership.md
@@ -1,0 +1,7 @@
+---
+'@eventcatalog/generator-asyncapi': major
+---
+
+Derive message ownership from the AsyncAPI operation action when no explicit `x-eventcatalog-role` is set. Sending services own shared contracts, while receiving services create a fallback only when the message is missing and otherwise reference the existing contract without overwriting it.
+
+This changes the default behavior of unannotated `receive` and `subscribe` operations, which previously owned and overwrote message documentation. Set `x-eventcatalog-role: provider` on the operation or message to retain that ownership behavior.

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -1,6 +1,6 @@
 import { AsyncAPIDocumentInterface, MessageInterface, Parser, fromFile, fromURL } from '@asyncapi/parser';
 import utils from '@eventcatalog/sdk';
-import { readFile } from 'node:fs/promises';
+import { cp, mkdir, readFile, rm } from 'node:fs/promises';
 import argv from 'minimist';
 import yaml from 'js-yaml';
 import { z } from 'zod';
@@ -230,6 +230,9 @@ export default async (config: any, options: Props) => {
     versionCommand,
     versionEvent,
     versionQuery,
+    rmCommandById,
+    rmEventById,
+    rmQueryById,
     addSchemaToCommand,
     addSchemaToEvent,
     addSchemaToQuery,
@@ -251,6 +254,7 @@ export default async (config: any, options: Props) => {
       write: writeEvent,
       version: versionEvent,
       get: getEvent,
+      remove: rmEventById,
       addSchema: addSchemaToEvent,
       addExample: addExampleToEvent,
       collection: 'events',
@@ -259,6 +263,7 @@ export default async (config: any, options: Props) => {
       write: writeCommand,
       version: versionCommand,
       get: getCommand,
+      remove: rmCommandById,
       addSchema: addSchemaToCommand,
       addExample: addExampleToCommand,
       collection: 'commands',
@@ -267,6 +272,7 @@ export default async (config: any, options: Props) => {
       write: writeQuery,
       version: versionQuery,
       get: getQuery,
+      remove: rmQueryById,
       addSchema: addSchemaToQuery,
       addExample: addExampleToQuery,
       collection: 'queries',
@@ -485,8 +491,9 @@ export default async (config: any, options: Props) => {
         const isMessageMarkedAsDraft =
           isDomainMarkedAsDraft || isServiceMarkedAsDraft || message.extensions().get('x-eventcatalog-draft')?.value() || null;
 
-        // does this service own or just consume the message?
-        const serviceOwnsMessageContract = isServiceMessageOwner(message, operation);
+        // Does this service own, reference, or treat the message as external?
+        const messageOwnership = getMessageOwnership(message, operation);
+        const serviceOwnsMessageContract = messageOwnership === 'owner';
         const isReceived = operation.action() === 'receive' || operation.action() === 'subscribe';
         const isSent = operation.action() === 'send' || operation.action() === 'publish';
 
@@ -509,6 +516,7 @@ export default async (config: any, options: Props) => {
           write: writeMessage,
           version: versionMessage,
           get: getMessage,
+          remove: removeMessage,
           addSchema: addSchemaToMessage,
           addExample: addExampleToMessage,
           collection: folder,
@@ -530,12 +538,16 @@ export default async (config: any, options: Props) => {
           messagePath = messageId;
         }
 
-        if (serviceOwnsMessageContract) {
+        if (messageOwnership === 'external') {
+          // An explicit client role means the contract is owned outside this service.
+          console.log(chalk.yellow(` - Skipping external message: ${getMessageName(message)}(v${messageVersion})`));
+        } else {
           // Check if the message already exists in the catalog
           const catalogedMessage = await getMessage(messageId, 'latest');
           let shouldWriteMessage = true;
+          let existingMessageDirectoryToRelocate: string | null = null;
 
-          if (catalogedMessage) {
+          if (serviceOwnsMessageContract && catalogedMessage) {
             // persist markdown, badges and attachments if it exists
             messageMarkdown = catalogedMessage.markdown;
             messageBadges = catalogedMessage.badges || null;
@@ -545,6 +557,16 @@ export default async (config: any, options: Props) => {
 
             if (isSameVersion(catalogedVersion, messageVersion)) {
               // Same version - continue and overwrite the message in place
+              const catalogedMessagePath = await getResourcePath(process.env.PROJECT_DIR as string, messageId, catalogedVersion);
+              const targetMessageDirectory = path.resolve(process.env.PROJECT_DIR as string, folder, messagePath);
+              const catalogedMessageDirectory = catalogedMessagePath ? path.dirname(catalogedMessagePath.fullPath) : null;
+
+              if (
+                catalogedMessageDirectory &&
+                path.normalize(catalogedMessageDirectory) !== path.normalize(targetMessageDirectory)
+              ) {
+                existingMessageDirectoryToRelocate = catalogedMessageDirectory;
+              }
             } else if (isNewerVersion(messageVersion, catalogedVersion)) {
               // Incoming is strictly newer - version the cataloged one and write the new one at root
               await versionMessage(messageId);
@@ -560,9 +582,32 @@ export default async (config: any, options: Props) => {
               messageVersion = catalogedVersion;
               shouldWriteMessage = false;
             }
+          } else if (!serviceOwnsMessageContract && catalogedMessage) {
+            // A receiver references the owner's existing contract and version without writing
+            // another copy beneath the receiving service.
+            console.log(
+              chalk.yellow(` - Referencing existing message ${messageId} (v${catalogedMessage.version}) without overwriting`)
+            );
+            messageVersion = catalogedMessage.version ?? messageVersion;
+            shouldWriteMessage = false;
           }
 
           if (shouldWriteMessage) {
+            if (existingMessageDirectoryToRelocate) {
+              const targetMessageDirectory = path.resolve(process.env.PROJECT_DIR as string, folder, messagePath);
+
+              // A receiver may have created a fallback before the owner was generated. Move
+              // that resource to the owner's location so the catalog retains one shared
+              // contract while preserving any files already attached to the fallback.
+              await removeMessage(messageId, messageVersion, true);
+              await mkdir(path.dirname(targetMessageDirectory), { recursive: true });
+              await cp(existingMessageDirectoryToRelocate, targetMessageDirectory, {
+                recursive: true,
+                force: true,
+              });
+              await rm(existingMessageDirectoryToRelocate, { recursive: true, force: true });
+            }
+
             await writeMessage(
               {
                 id: messageId,
@@ -581,7 +626,9 @@ export default async (config: any, options: Props) => {
                 ...(isMessageMarkedAsDraft && { draft: true }),
               },
               {
-                override: true,
+                // References only reach this branch when the message is missing. They may
+                // create a fallback, but only owners may replace an existing contract.
+                override: serviceOwnsMessageContract,
                 path: messagePath,
               }
             );
@@ -625,9 +672,6 @@ export default async (config: any, options: Props) => {
               }
             }
           }
-        } else {
-          // Message is not owned by this service, therefore we don't need to document it
-          console.log(chalk.yellow(` - Skipping external message: ${getMessageName(message)}(v${messageVersion})`));
         }
         // Derive group from x-eventcatalog-group extension if groupMessagesBy is configured
         const group =
@@ -835,19 +879,31 @@ const isJSONSchemaMessage = (message: MessageInterface) => {
   return getSchemaFileName(message).endsWith('.json');
 };
 /**
- * Is the AsyncAPI specification (service) the owner of the message?
- * This is determined by the 'x-eventcatalog-role' extension in the message
+ * How the service described by the AsyncAPI document relates to a message.
  *
- * @param message
- * @returns boolean
- *
- * default is provider (AsyncAPI file / service owns the message)
+ * Explicit operation- or message-level roles retain their existing meaning and
+ * take precedence over the operation action. Without an explicit role, senders
+ * own the contract and receivers only reference it.
  */
-const isServiceMessageOwner = (message: MessageInterface, operation?: { extensions: () => any }): boolean => {
-  // Prefer operation-level override to support shared/ref'ed messages where ownership
-  // needs to be set per operation/service.
+type MessageOwnership = 'owner' | 'reference' | 'external';
+
+const getMessageOwnership = (
+  message: MessageInterface,
+  operation?: { extensions: () => any; action?: () => string }
+): MessageOwnership => {
+  // Prefer operation-level overrides for shared messages whose role differs per operation.
   const operationRole = operation?.extensions?.().get?.('x-eventcatalog-role')?.value?.();
   const messageRole = message.extensions().get('x-eventcatalog-role')?.value();
-  const value = operationRole || messageRole || 'provider';
-  return value === 'provider';
+  const explicitRole = operationRole || messageRole;
+
+  if (explicitRole) {
+    return explicitRole === 'provider' ? 'owner' : 'external';
+  }
+
+  const action = operation?.action?.();
+  if (action === 'receive' || action === 'subscribe') {
+    return 'reference';
+  }
+
+  return 'owner';
 };

--- a/packages/generator-asyncapi/src/test/asyncapi-files/ownership-explicit-client.asyncapi.yml
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/ownership-explicit-client.asyncapi.yml
@@ -1,0 +1,28 @@
+asyncapi: 3.0.0
+info:
+  title: Relay Service
+  version: 1.0.0
+  description: Sends OrderPlaced but explicitly treats its contract as external
+channels:
+  orders:
+    address: orders
+    messages:
+      OrderPlaced:
+        $ref: '#/components/messages/OrderPlaced'
+operations:
+  sendOrderPlaced:
+    action: send
+    x-eventcatalog-role: client
+    channel:
+      $ref: '#/channels/orders'
+    messages:
+      - $ref: '#/channels/orders/messages/OrderPlaced'
+components:
+  messages:
+    OrderPlaced:
+      summary: External message must not be documented
+      payload:
+        type: object
+        properties:
+          relayId:
+            type: string

--- a/packages/generator-asyncapi/src/test/asyncapi-files/ownership-explicit-provider.asyncapi.yml
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/ownership-explicit-provider.asyncapi.yml
@@ -1,0 +1,28 @@
+asyncapi: 3.0.0
+info:
+  title: Audit Service
+  version: 1.0.0
+  description: Receives OrderPlaced but explicitly owns its contract
+channels:
+  orders:
+    address: orders
+    messages:
+      OrderPlaced:
+        $ref: '#/components/messages/OrderPlaced'
+operations:
+  receiveOrderPlaced:
+    action: receive
+    x-eventcatalog-role: provider
+    channel:
+      $ref: '#/channels/orders'
+    messages:
+      - $ref: '#/channels/orders/messages/OrderPlaced'
+components:
+  messages:
+    OrderPlaced:
+      summary: Explicit provider owns this message
+      payload:
+        type: object
+        properties:
+          auditId:
+            type: string

--- a/packages/generator-asyncapi/src/test/asyncapi-files/ownership-publisher.asyncapi.yml
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/ownership-publisher.asyncapi.yml
@@ -1,0 +1,29 @@
+asyncapi: 3.0.0
+info:
+  title: Order Service
+  version: 1.0.0
+  description: Publishes OrderPlaced
+channels:
+  orders:
+    address: orders
+    messages:
+      OrderPlaced:
+        $ref: '#/components/messages/OrderPlaced'
+operations:
+  sendOrderPlaced:
+    action: send
+    channel:
+      $ref: '#/channels/orders'
+    messages:
+      - $ref: '#/channels/orders/messages/OrderPlaced'
+components:
+  messages:
+    OrderPlaced:
+      summary: Owned by the order service
+      payload:
+        type: object
+        properties:
+          orderId:
+            type: string
+          amount:
+            type: number

--- a/packages/generator-asyncapi/src/test/asyncapi-files/ownership-receiver.asyncapi.yml
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/ownership-receiver.asyncapi.yml
@@ -1,0 +1,27 @@
+asyncapi: 3.0.0
+info:
+  title: Notification Service
+  version: 1.0.0
+  description: Receives OrderPlaced
+channels:
+  orders:
+    address: orders
+    messages:
+      OrderPlaced:
+        $ref: '#/components/messages/OrderPlaced'
+operations:
+  receiveOrderPlaced:
+    action: receive
+    channel:
+      $ref: '#/channels/orders'
+    messages:
+      - $ref: '#/channels/orders/messages/OrderPlaced'
+components:
+  messages:
+    OrderPlaced:
+      summary: Receiver's fallback description
+      payload:
+        type: object
+        properties:
+          orderId:
+            type: string

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -1252,6 +1252,147 @@ describe('AsyncAPI EventCatalog Plugin', () => {
   });
 
   describe('messages', () => {
+    describe('rules', () => {
+      describe('message ownership', () => {
+        it('rule 1: an explicit `provider` role wins over a `receive` action and owns the message', async () => {
+          const { getEvent, getService } = utils(catalogDir);
+
+          // Use the same service id so both definitions target the same on-disk message.
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'ownership-publisher.asyncapi.yml'), id: 'audit-service' }],
+          });
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'ownership-explicit-provider.asyncapi.yml'), id: 'audit-service' }],
+          });
+
+          const event = await getEvent('OrderPlaced', 'latest', { attachSchema: true });
+          const service = await getService('audit-service', '1.0.0');
+
+          expect(event.summary).toEqual('Explicit provider owns this message');
+          expect(event.schema.properties).toHaveProperty('auditId');
+          expect(service.receives).toContainEqual({ id: 'OrderPlaced', version: '1.0.0' });
+        });
+
+        it('rule 1: an explicit `client` role wins over a `send` action and leaves the message external', async () => {
+          const { getEvent, getService } = utils(catalogDir);
+
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'ownership-explicit-client.asyncapi.yml'), id: 'relay-service' }],
+          });
+
+          const event = await getEvent('OrderPlaced', 'latest');
+          const service = await getService('relay-service', '1.0.0');
+
+          expect(event).toBeUndefined();
+          expect(service.sends).toContainEqual({ id: 'OrderPlaced', version: '1.0.0' });
+        });
+
+        it('rule 2: without an explicit role, a `send` action owns and documents the message', async () => {
+          const { getEvent, getService } = utils(catalogDir);
+
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'ownership-publisher.asyncapi.yml'), id: 'order-service' }],
+          });
+
+          const event = await getEvent('OrderPlaced', 'latest', { attachSchema: true });
+          const service = await getService('order-service', '1.0.0');
+
+          expect(event.summary).toEqual('Owned by the order service');
+          expect(event.schema.properties).toHaveProperty('amount');
+          expect(service.sends).toContainEqual({ id: 'OrderPlaced', version: '1.0.0' });
+        });
+
+        it('rule 3: without an explicit role, a `receive` action creates a fallback when the message is missing', async () => {
+          const { getEvent, getService } = utils(catalogDir);
+
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'ownership-receiver.asyncapi.yml'), id: 'notification-service' }],
+          });
+
+          const event = await getEvent('OrderPlaced', 'latest');
+          const service = await getService('notification-service', '1.0.0');
+
+          expect(event.summary).toEqual("Receiver's fallback description");
+          expect(existsSync(join(catalogDir, 'services', 'notification-service', 'events', 'OrderPlaced'))).toBe(true);
+          expect(service.receives).toContainEqual({ id: 'OrderPlaced', version: '1.0.0' });
+        });
+
+        it('rule 3: without an explicit role, a `receive` action references an existing message without overwriting it', async () => {
+          const { getEvent, getService } = utils(catalogDir);
+
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'ownership-publisher.asyncapi.yml'), id: 'order-service' }],
+          });
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'ownership-receiver.asyncapi.yml'), id: 'notification-service' }],
+          });
+
+          const event = await getEvent('OrderPlaced', 'latest', { attachSchema: true });
+          const service = await getService('notification-service', '1.0.0');
+
+          expect(event.summary).toEqual('Owned by the order service');
+          expect(event.schema.properties).toHaveProperty('amount');
+          expect(existsSync(join(catalogDir, 'services', 'notification-service', 'events', 'OrderPlaced'))).toBe(false);
+          expect(service.receives).toContainEqual({ id: 'OrderPlaced', version: '1.0.0' });
+        });
+
+        it('rule 4: a producer replaces a fallback that was created by a receiver', async () => {
+          const { getEvent, getService } = utils(catalogDir);
+
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'ownership-receiver.asyncapi.yml'), id: 'notification-service' }],
+          });
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'ownership-publisher.asyncapi.yml'), id: 'order-service' }],
+          });
+
+          const event = await getEvent('OrderPlaced', 'latest', { attachSchema: true });
+          const publisher = await getService('order-service', '1.0.0');
+          const receiver = await getService('notification-service', '1.0.0');
+
+          expect(event.summary).toEqual('Owned by the order service');
+          expect(event.schema.properties).toHaveProperty('amount');
+          expect(existsSync(join(catalogDir, 'services', 'notification-service', 'events', 'OrderPlaced'))).toBe(false);
+          expect(existsSync(join(catalogDir, 'services', 'order-service', 'events', 'OrderPlaced'))).toBe(true);
+          expect(publisher.sends).toContainEqual({ id: 'OrderPlaced', version: '1.0.0' });
+          expect(receiver.receives).toContainEqual({ id: 'OrderPlaced', version: '1.0.0' });
+        });
+
+        it('rule 5: the producer remains authoritative regardless of generation order', async () => {
+          const { getEvent } = utils(catalogDir);
+
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'ownership-publisher.asyncapi.yml'), id: 'order-service' }],
+          });
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'ownership-receiver.asyncapi.yml'), id: 'notification-service' }],
+          });
+
+          const event = await getEvent('OrderPlaced', 'latest', { attachSchema: true });
+
+          expect(event.summary).toEqual('Owned by the order service');
+          expect(event.schema.properties).toHaveProperty('amount');
+        });
+
+        it('rule 6: ownership does not change the service `sends` and `receives` relationships', async () => {
+          const { getService } = utils(catalogDir);
+
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'ownership-publisher.asyncapi.yml'), id: 'order-service' }],
+          });
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'ownership-receiver.asyncapi.yml'), id: 'notification-service' }],
+          });
+
+          const publisher = await getService('order-service', '1.0.0');
+          const receiver = await getService('notification-service', '1.0.0');
+
+          expect(publisher.sends).toContainEqual({ id: 'OrderPlaced', version: '1.0.0' });
+          expect(receiver.receives).toContainEqual({ id: 'OrderPlaced', version: '1.0.0' });
+        });
+      });
+    });
+
     it('messages that do not have an eventcatalog header are documented as events by default in EventCatalog', async () => {
       const { getEvent } = utils(catalogDir);
 

--- a/packages/generator-asyncapi/src/types.ts
+++ b/packages/generator-asyncapi/src/types.ts
@@ -3,6 +3,7 @@ export interface MessageOperations {
   write: (payload: any, options: any) => Promise<void>;
   version: (id: string) => Promise<any>;
   get: (id: string, version: string) => Promise<any>;
+  remove: (id: string, version?: string, persistFiles?: boolean) => Promise<void>;
   addSchema: (id: string, schema: any, version: any, options: { path: string }) => Promise<void>;
   addExample: (id: string, example: { content: string; fileName: string }, version?: string) => Promise<void>;
   collection: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,14 +88,14 @@ importers:
         specifier: '>=6.4.3'
         version: 6.4.3
       '@eventcatalog/generator-openapi':
-        specifier: '>=7.12.12'
-        version: 7.12.12(@types/node@20.19.1)
+        specifier: '>=8.0.0'
+        version: 8.0.0(@types/node@20.19.1)
       '@eventcatalog/sdk':
         specifier: ^2.18.2
         version: 2.18.2
       axios:
-        specifier: ^1.13.5
-        version: 1.13.6
+        specifier: ^1.18.0
+        version: 1.18.1
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -1209,8 +1209,8 @@ packages:
   '@eventcatalog/generator-asyncapi@6.4.3':
     resolution: { integrity: sha512-VUlLJm5kuXR7FtWzYIzFnPPwpRR1LU+ilXRhjVjSAm+E8Jc5OS3U8JZgGnU16YJRylhqm7dnqlNALBpyQv4YIA== }
 
-  '@eventcatalog/generator-openapi@7.12.12':
-    resolution: { integrity: sha512-wzo4i/cxYWewsFkNHNxocWThBxs7LPfvnuAQ8bkCV2DbO6g9Rlf9iRdvqH3BNRZlZFR8j0xTDtwcxSbMYEInDQ== }
+  '@eventcatalog/generator-openapi@8.0.0':
+    resolution: { integrity: sha512-u/rmuAuKAic2JDbIfxiejYe7mZtd1KaUk4azccAHoWwwT/pBEgL+3UATzje27w8hQ2LyMh5RPAk9L566u6+xqg== }
 
   '@eventcatalog/license@0.0.7':
     resolution: { integrity: sha512-izSIn3Dfc6LTcPiA89EqZ4/l5WCitLxt0XVu2yilyaibMOioxW7ABRFZY8/Azocd6ULKseVA2lCcoeT35/GRcg== }
@@ -2024,6 +2024,10 @@ packages:
     engines: { node: '>=0.4.0' }
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: { integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ== }
+    engines: { node: '>= 6.0.0' }
+
   agent-base@7.1.4:
     resolution: { integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ== }
     engines: { node: '>= 14' }
@@ -2124,6 +2128,9 @@ packages:
 
   axios@1.13.6:
     resolution: { integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ== }
+
+  axios@1.18.1:
+    resolution: { integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g== }
 
   balanced-match@1.0.2:
     resolution: { integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw== }
@@ -2472,6 +2479,15 @@ packages:
       debug:
         optional: true
 
+  follow-redirects@1.16.0:
+    resolution: { integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw== }
+    engines: { node: '>=4.0' }
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: { integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg== }
     engines: { node: '>= 0.4' }
@@ -2614,6 +2630,10 @@ packages:
   hasown@2.0.2:
     resolution: { integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ== }
     engines: { node: '>= 0.4' }
+
+  https-proxy-agent@5.0.1:
+    resolution: { integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA== }
+    engines: { node: '>= 6' }
 
   https-proxy-agent@7.0.6:
     resolution: { integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw== }
@@ -3129,6 +3149,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: { integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg== }
+
+  proxy-from-env@2.1.0:
+    resolution: { integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA== }
+    engines: { node: '>=10' }
 
   punycode@2.3.1:
     resolution: { integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg== }
@@ -5040,7 +5064,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@eventcatalog/generator-openapi@7.12.12(@types/node@20.19.1)':
+  '@eventcatalog/generator-openapi@8.0.0(@types/node@20.19.1)':
     dependencies:
       '@apidevtools/swagger-parser': 12.1.0(openapi-types@12.1.3)
       '@changesets/cli': 2.29.8(@types/node@20.19.1)
@@ -6238,6 +6262,12 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv-draft-04@1.0.0(ajv@8.17.1):
@@ -6326,6 +6356,16 @@ snapshots:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   balanced-match@1.0.2: {}
 
@@ -6767,6 +6807,8 @@ snapshots:
 
   follow-redirects@1.15.11: {}
 
+  follow-redirects@1.16.0: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -6945,6 +6987,13 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -7384,6 +7433,8 @@ snapshots:
   proto-list@1.2.4: {}
 
   proxy-from-env@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION

## What This PR Does

Changes how the AsyncAPI generator decides whether a service owns a message contract when no explicit `x-eventcatalog-role` is set. Previously every operation defaulted to `provider`, so a receiving service would overwrite message documentation created by the sending service. Now the operation action drives the default: senders own the contract, receivers only reference it.

## Changes Overview

### Key Changes

- Replace the boolean `isServiceMessageOwner` helper with `getMessageOwnership`, which returns one of three ownership modes: `owner`, `reference`, or `external`
- Without an explicit role, `send`/`publish` operations own the message, and `receive`/`subscribe` operations reference it
- Explicit `x-eventcatalog-role` values keep their existing meaning and take precedence: `provider` means owner, `client` means external (skipped entirely)
- Receivers reference an existing cataloged message without overwriting it, adopting the cataloged version
- If the message does not exist yet, a receiver creates a fallback copy so the catalog is never missing documentation
- When the owner is later generated and the fallback lives in a different directory, the generator relocates the existing resource to the owner's location, preserving markdown, badges, and attached files
- Add a `remove` operation to `MessageOperations` to support the relocation flow
- Add four AsyncAPI test fixtures and tests covering publisher ownership, receiver fallback, and explicit provider/client roles

## How It Works

`getMessageOwnership` checks the operation-level extension first, then the message-level extension, then falls back to the operation action. Ownership drives three write paths: owners write with `override: true` as before; references only write when the message is missing from the catalog (with `override: false` so they can never clobber an existing contract); external messages are skipped with a log line. The relocation path uses the SDK's `getResourcePath` to detect when the cataloged copy lives somewhere other than the owner's target directory, then removes the old entry (persisting files) and copies the directory into place.

## Breaking Changes

Unannotated `receive` and `subscribe` operations no longer own and overwrite message documentation. Catalogs relying on the old behavior should set `x-eventcatalog-role: provider` on the operation or message. Released as a major version bump of `@eventcatalog/generator-asyncapi`.

## Additional Notes

The changeset (`asyncapi-action-based-ownership.md`) is included with a `major` bump.