### PR TITLE
Add `preserveExistingMessages` option to AsyncAPI generator

### DIFF
--- a/.changeset/fresh-taxis-listen.md
+++ b/.changeset/fresh-taxis-listen.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/generator-asyncapi': patch
+---
+
+Add a `preserveExistingMessages` option to allow generated message markdown to overwrite existing content.

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -63,6 +63,7 @@ const cliArgs = argv(process.argv.slice(2));
 const optionsSchema = z.object({
   licenseKey: z.string().optional(),
   writeFilesToRoot: z.boolean().optional(),
+  preserveExistingMessages: z.boolean().optional(),
   services: z.array(
     z.object({
       id: z.string({ required_error: 'The service id is required. please provide the service id' }),
@@ -289,6 +290,7 @@ export default async (config: any, options: Props) => {
     parseChannels = false,
     parseExamples = true,
     attachHeadersToSchema = false,
+    preserveExistingMessages = true,
   } = options;
   // const asyncAPIFiles = Array.isArray(options.path) ? options.path : [options.path];
   console.log(chalk.green(`Processing ${services.length} AsyncAPI files...`));
@@ -548,10 +550,13 @@ export default async (config: any, options: Props) => {
           let existingMessageDirectoryToRelocate: string | null = null;
 
           if (serviceOwnsMessageContract && catalogedMessage) {
-            // persist markdown, badges and attachments if it exists
-            messageMarkdown = catalogedMessage.markdown;
+            // Always preserve user-managed badges and attachments.
             messageBadges = catalogedMessage.badges || null;
             messageAttachments = catalogedMessage.attachments || null;
+
+            if (preserveExistingMessages) {
+              messageMarkdown = catalogedMessage.markdown;
+            }
 
             const catalogedVersion = catalogedMessage.version ?? '';
 

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -1317,13 +1317,14 @@ describe('AsyncAPI EventCatalog Plugin', () => {
           expect(service.receives).toContainEqual({ id: 'OrderPlaced', version: '1.0.0' });
         });
 
-        it('rule 3: without an explicit role, a `receive` action references an existing message without overwriting it', async () => {
+        it('rule 3: without an explicit role, a `receive` action references an existing message without overwriting it even when preserveExistingMessages is false', async () => {
           const { getEvent, getService } = utils(catalogDir);
 
           await plugin(config, {
             services: [{ path: join(asyncAPIExamplesDir, 'ownership-publisher.asyncapi.yml'), id: 'order-service' }],
           });
           await plugin(config, {
+            preserveExistingMessages: false,
             services: [{ path: join(asyncAPIExamplesDir, 'ownership-receiver.asyncapi.yml'), id: 'notification-service' }],
           });
 
@@ -1541,7 +1542,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
       expect(latest.markdown).toEqual('cataloged at v2.0.0');
     });
 
-    it('when a message already exists in EventCatalog the markdown, badges and attachments are persisted and not overwritten', async () => {
+    it('when a message already exists in EventCatalog the markdown, badges and attachments are persisted and not overwritten by default', async () => {
       const { writeEvent, getEvent } = utils(catalogDir);
 
       await writeEvent({
@@ -1559,6 +1560,26 @@ describe('AsyncAPI EventCatalog Plugin', () => {
       expect(newEvent.markdown).toEqual('please dont override me!');
       expect(newEvent.badges).toEqual([{ backgroundColor: 'red', textColor: 'white', content: 'Custom Badge' }]);
       expect(newEvent.attachments).toEqual(['https://github.com/dboyne/eventcatalog/blob/main/README.md']);
+    });
+
+    it('when preserveExistingMessages is set to false, the existing markdown is overwritten', async () => {
+      const { writeEvent, getEvent } = utils(catalogDir);
+
+      await writeEvent({
+        id: 'UserSignedUp',
+        version: '1.0.0',
+        name: 'UserSignedUp',
+        markdown: 'This markdown is already in the catalog',
+      });
+
+      await plugin(config, {
+        preserveExistingMessages: false,
+        services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service' }],
+      });
+
+      const event = await getEvent('UserSignedUp', '1.0.0');
+      expect(event.markdown).not.toContain('This markdown is already in the catalog');
+      expect(event.markdown).toContain('## Schema');
     });
 
     it('when a message already exists in EventCatalog with the same version the metadata is updated', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^2.27.8
         version: 2.29.5
       '@eventcatalog/generator-asyncapi':
-        specifier: '>=6.4.3'
-        version: 6.4.3
+        specifier: '>=7.0.0'
+        version: 7.0.0
       '@eventcatalog/generator-openapi':
         specifier: '>=8.0.0'
         version: 8.0.0(@types/node@20.19.1)
@@ -1206,8 +1206,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@eventcatalog/generator-asyncapi@6.4.3':
-    resolution: { integrity: sha512-VUlLJm5kuXR7FtWzYIzFnPPwpRR1LU+ilXRhjVjSAm+E8Jc5OS3U8JZgGnU16YJRylhqm7dnqlNALBpyQv4YIA== }
+  '@eventcatalog/generator-asyncapi@7.0.0':
+    resolution: { integrity: sha512-4X0op+G+9e9g/H0upmxvZChIv/O9LssIpv4PlBPrS8NthiE7jDtAwguTRUj9PiYhBzgbFsw1dAN5hwYS+iQxow== }
 
   '@eventcatalog/generator-openapi@8.0.0':
     resolution: { integrity: sha512-u/rmuAuKAic2JDbIfxiejYe7mZtd1KaUk4azccAHoWwwT/pBEgL+3UATzje27w8hQ2LyMh5RPAk9L566u6+xqg== }
@@ -5045,7 +5045,7 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
-  '@eventcatalog/generator-asyncapi@6.4.3':
+  '@eventcatalog/generator-asyncapi@7.0.0':
     dependencies:
       '@asyncapi/avro-schema-parser': 3.0.24
       '@asyncapi/parser': 3.6.0


### PR DESCRIPTION
Closes https://github.com/event-catalog/generators/issues/417

## What This PR Does

Adds a new `preserveExistingMessages` option to the AsyncAPI generator. By default (`true`), the generator keeps existing message markdown in the catalog untouched — the current behavior. When set to `false`, the generator overwrites existing message markdown with freshly generated content on each run, which is useful when users want their AsyncAPI files to remain the source of truth for message documentation.

## Changes Overview

### Key Changes

- Add `preserveExistingMessages` to the generator options schema (optional boolean, defaults to `true`)
- When `preserveExistingMessages: false`, existing message markdown is regenerated from the AsyncAPI file instead of being persisted
- User-managed badges and attachments are always preserved, regardless of this option
- Add a changeset (`patch`) for `@eventcatalog/generator-asyncapi`

### Tests

- New test verifying markdown is overwritten when `preserveExistingMessages: false`
- Updated existing tests to clarify default (preserve) behavior
- Verified that messages a service does not own (e.g. referenced via a `receive` action without an explicit role) are still never overwritten, even with `preserveExistingMessages: false`

## How It Works

When processing a message the service owns, the generator previously always reused the cataloged message's markdown. Now the markdown is only reused when `preserveExistingMessages` is `true` (the default). Badges and attachments continue to be carried over unconditionally, since these are user-managed and not derived from the AsyncAPI file.

## Breaking Changes

None — the default behavior is unchanged.

## Additional Notes

Documentation for the new option should be added to the AsyncAPI generator docs on the EventCatalog website.