### PR TITLE
fix(asyncapi): preserve shared references when saving parsed spec files

### DIFF
--- a/.changeset/lazy-donkeys-repair.md
+++ b/.changeset/lazy-donkeys-repair.md
@@ -1,0 +1,13 @@
+---
+'@eventcatalog/generator-asyncapi': patch
+---
+
+fix(asyncapi): stop `saveParsedSpecFile` producing invalid AsyncAPI v3 documents
+
+Parsed AsyncAPI v3 documents contain shared (non-circular) object references, e.g.
+each operation's dereferenced `channel` is the same object as the entry under the
+root `channels` object. The circular-reference-safe serializer treated these shared
+references as cycles and replaced them with `$ref: '#'`, producing a spec file that
+fails AsyncAPI validation and renders as a blank page in EventCatalog. The serializer
+now tracks ancestors instead of every object seen, so only true cycles are replaced
+with a `$ref`.

--- a/packages/generator-asyncapi/src/index.ts
+++ b/packages/generator-asyncapi/src/index.ts
@@ -31,30 +31,47 @@ import { join } from 'node:path';
 const parser = new Parser();
 
 /**
- * Safely stringify objects that may contain circular references.
- * When a circular ref is detected, it uses the `x-parser-schema-id` property
+ * Deep copy that breaks circular references while preserving shared (non-circular)
+ * references. When a true cycle is detected, it uses the `x-parser-schema-id` property
  * to reconstruct a valid JSON Schema `$ref` (e.g. `#/components/schemas/MySchema`).
+ *
+ * Ancestors are tracked (rather than every object ever seen) because parsed AsyncAPI
+ * documents contain shared references that are not circular — e.g. each operation's
+ * dereferenced `channel` is the same object as the entry under the root `channels`
+ * object. Replacing those with a `$ref` produces an invalid spec that fails to re-parse.
  */
-const safeStringify = (obj: unknown, indent?: number): string => {
-  const seen = new WeakSet();
-  return JSON.stringify(
-    obj,
-    (_key, value) => {
-      if (typeof value === 'object' && value !== null) {
-        if (seen.has(value)) {
-          const schemaId = (value as Record<string, unknown>)['x-parser-schema-id'];
-          if (schemaId && typeof schemaId === 'string') {
-            return { $ref: `#/components/schemas/${schemaId}` };
-          }
-          return { $ref: '#' };
-        }
-        seen.add(value);
-      }
-      return value;
-    },
-    indent
-  );
+const breakCircularReferences = (value: unknown, ancestors = new WeakSet()): unknown => {
+  if (typeof value !== 'object' || value === null) return value;
+
+  if (ancestors.has(value)) {
+    const schemaId = (value as Record<string, unknown>)['x-parser-schema-id'];
+    if (schemaId && typeof schemaId === 'string') {
+      return { $ref: `#/components/schemas/${schemaId}` };
+    }
+    return { $ref: '#' };
+  }
+
+  ancestors.add(value);
+
+  let result: unknown;
+  if (Array.isArray(value)) {
+    result = value.map((item) => breakCircularReferences(item, ancestors));
+  } else {
+    const obj: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+      obj[key] = breakCircularReferences(item, ancestors);
+    }
+    result = obj;
+  }
+
+  ancestors.delete(value);
+  return result;
 };
+
+/**
+ * Safely stringify objects that may contain circular references.
+ */
+const safeStringify = (obj: unknown, indent?: number): string => JSON.stringify(breakCircularReferences(obj), null, indent);
 
 // register avro schema support
 parser.registerSchemaParser(AvroSchemaParser());
@@ -822,7 +839,7 @@ const getParsedSpecFile = (service: Service, document: AsyncAPIDocumentInterface
   const isSpecFileJSON = service.path.endsWith('.json');
   return isSpecFileJSON
     ? safeStringify(document.meta().asyncapi.parsed, 4)
-    : yaml.dump(document.meta().asyncapi.parsed, { noRefs: true });
+    : yaml.dump(breakCircularReferences(document.meta().asyncapi.parsed), { noRefs: true });
 };
 
 const getRawSpecFile = async (service: Service) => {

--- a/packages/generator-asyncapi/src/test/asyncapi-files/operations-channel-refs.asyncapi.json
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/operations-channel-refs.asyncapi.json
@@ -1,0 +1,100 @@
+{
+  "asyncapi": "3.0.0",
+  "id": "urn:example:registrations-service",
+  "defaultContentType": "application/json",
+  "info": {
+    "title": "registrations-service",
+    "description": "Example service that receives and publishes registration events",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "registrations_inbound": {
+      "address": "registrations_inbound",
+      "title": "registrations inbound",
+      "summary": "events the service receives",
+      "messages": {
+        "ApplicantRegistered_1.0.0": {
+          "name": "Applicant Registered",
+          "description": "An applicant has been registered",
+          "contentType": "application/json",
+          "correlationId": {
+            "description": "Default Correlation ID",
+            "location": "$message.header#/traceparent"
+          },
+          "x-eventcatalog-message-type": "event",
+          "x-eventcatalog-role": "client",
+          "x-eventcatalog-message-version": "1.0.0",
+          "headers": {
+            "type": "object",
+            "properties": {
+              "__TypeId__": {
+                "type": "string",
+                "const": "registrations/inbound/applicantRegistered/1.0.0"
+              },
+              "traceparent": {
+                "type": "string"
+              }
+            },
+            "x-eventcatalog-message-kafka-key": "applicantId"
+          },
+          "payload": {
+            "schema": {
+              "$ref": "./schema/ApplicantRegistered_1.0.0.schema.json"
+            }
+          }
+        }
+      }
+    },
+    "registrations_outbound": {
+      "address": "registrations_outbound",
+      "title": "registrations outbound",
+      "summary": "events the service publishes",
+      "messages": {
+        "RegistrationCompleted_1.0.0": {
+          "name": "Registration Completed",
+          "description": "A registration has been completed",
+          "contentType": "application/json",
+          "correlationId": {
+            "description": "Default Correlation ID",
+            "location": "$message.header#/traceparent"
+          },
+          "x-eventcatalog-message-type": "event",
+          "x-eventcatalog-role": "provider",
+          "x-eventcatalog-message-version": "1.0.0",
+          "headers": {
+            "type": "object",
+            "properties": {
+              "__TypeId__": {
+                "type": "string",
+                "const": "registrations/outbound/registrationCompleted/1.0.0"
+              },
+              "traceparent": {
+                "type": "string"
+              }
+            },
+            "x-eventcatalog-message-kafka-key": "caseId"
+          },
+          "payload": {
+            "schema": {
+              "$ref": "./schema/RegistrationCompleted_1.0.0.schema.json"
+            }
+          }
+        }
+      }
+    }
+  },
+  "operations": {
+    "consumeFromregistrations_inbound": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/registrations_inbound"
+      }
+    },
+    "publishToregistrations_outbound": {
+      "action": "send",
+      "channel": {
+        "$ref": "#/channels/registrations_outbound"
+      }
+    }
+  }
+}

--- a/packages/generator-asyncapi/src/test/asyncapi-files/schema/ApplicantRegistered_1.0.0.schema.json
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/schema/ApplicantRegistered_1.0.0.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "example:applicantRegistered/v1.0.0",
+  "title": "Applicant Registered",
+  "description": "An applicant has been registered",
+  "type": "object",
+  "properties": {
+    "applicantId": {
+      "description": "Identifier of the applicant",
+      "type": "string",
+      "format": "uuid",
+      "maxLength": 36
+    },
+    "caseId": {
+      "description": "Identifier of the case the applicant belongs to",
+      "type": "string",
+      "format": "uuid",
+      "maxLength": 36
+    },
+    "registeredAt": {
+      "description": "Timestamp the applicant was registered",
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": ["applicantId", "caseId"],
+  "additionalProperties": false
+}

--- a/packages/generator-asyncapi/src/test/asyncapi-files/schema/RegistrationCompleted_1.0.0.schema.json
+++ b/packages/generator-asyncapi/src/test/asyncapi-files/schema/RegistrationCompleted_1.0.0.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "example:registrationCompleted/v1.0.0",
+  "title": "Registration Completed",
+  "description": "A registration has been completed",
+  "type": "object",
+  "properties": {
+    "caseId": {
+      "description": "Identifier of the completed case",
+      "type": "string",
+      "format": "uuid",
+      "maxLength": 36
+    },
+    "completedAt": {
+      "description": "Timestamp the registration was completed",
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": ["caseId"],
+  "additionalProperties": false
+}

--- a/packages/generator-asyncapi/src/test/plugin.test.ts
+++ b/packages/generator-asyncapi/src/test/plugin.test.ts
@@ -1,5 +1,6 @@
 import { expect, it, describe, beforeEach, afterEach } from 'vitest';
 import utils from '@eventcatalog/sdk';
+import { Parser } from '@asyncapi/parser';
 import plugin from '../index';
 import { join } from 'node:path';
 import fs from 'fs/promises';
@@ -2387,6 +2388,31 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         const normalizeLineEndings = (str: string) => str.replace(/\r\n/g, '\n');
 
         expect(normalizeLineEndings(asyncAPIFile.trim())).toEqual(normalizeLineEndings(expected.trim()));
+      });
+
+      it('when `saveParsedSpecFile` is true and an AsyncAPI v3 document has operations referencing channels, the saved spec file is still a valid AsyncAPI document', async () => {
+        await plugin(config, {
+          services: [{ path: join(asyncAPIExamplesDir, 'operations-channel-refs.asyncapi.json'), id: 'registrations-service' }],
+          saveParsedSpecFile: true,
+        });
+
+        const savedSpecFile = (
+          await fs.readFile(join(catalogDir, 'services', 'registrations-service', 'operations-channel-refs.asyncapi.json'))
+        ).toString();
+
+        // Shared (non-circular) references, e.g. each operation's dereferenced channel,
+        // must not be collapsed into `$ref: '#'` self references
+        expect(savedSpecFile).not.toContain('"$ref": "#"');
+
+        const parsed = JSON.parse(savedSpecFile);
+        expect(parsed.operations.consumeFromregistrations_inbound.channel.address).toEqual('registrations_inbound');
+        expect(parsed.operations.publishToregistrations_outbound.channel.address).toEqual('registrations_outbound');
+
+        // The saved spec file is what EventCatalog parses and renders on the AsyncAPI page,
+        // an invalid document results in a blank page
+        const { document, diagnostics } = await new Parser().parse(savedSpecFile);
+        expect(document).toBeDefined();
+        expect(diagnostics.filter((diagnostic) => diagnostic.severity === 0)).toEqual([]);
       });
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: '>=7.0.0'
         version: 7.0.0
       '@eventcatalog/generator-openapi':
-        specifier: '>=8.0.0'
-        version: 8.0.0(@types/node@20.19.1)
+        specifier: '>=9.0.0'
+        version: 9.0.0(@types/node@20.19.1)
       '@eventcatalog/sdk':
         specifier: ^2.18.2
         version: 2.18.2
@@ -1209,8 +1209,8 @@ packages:
   '@eventcatalog/generator-asyncapi@7.0.0':
     resolution: { integrity: sha512-4X0op+G+9e9g/H0upmxvZChIv/O9LssIpv4PlBPrS8NthiE7jDtAwguTRUj9PiYhBzgbFsw1dAN5hwYS+iQxow== }
 
-  '@eventcatalog/generator-openapi@8.0.0':
-    resolution: { integrity: sha512-u/rmuAuKAic2JDbIfxiejYe7mZtd1KaUk4azccAHoWwwT/pBEgL+3UATzje27w8hQ2LyMh5RPAk9L566u6+xqg== }
+  '@eventcatalog/generator-openapi@9.0.0':
+    resolution: { integrity: sha512-POndhlpBDkWaem9e3v9W9HISt6fNOTTEo/ZK5VUtM4tjojlsfdM9FJoqoDTaxXflZiL5NzrQtpIcb/sf+fUfug== }
 
   '@eventcatalog/license@0.0.7':
     resolution: { integrity: sha512-izSIn3Dfc6LTcPiA89EqZ4/l5WCitLxt0XVu2yilyaibMOioxW7ABRFZY8/Azocd6ULKseVA2lCcoeT35/GRcg== }
@@ -5064,7 +5064,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@eventcatalog/generator-openapi@8.0.0(@types/node@20.19.1)':
+  '@eventcatalog/generator-openapi@9.0.0(@types/node@20.19.1)':
     dependencies:
       '@apidevtools/swagger-parser': 12.1.0(openapi-types@12.1.3)
       '@changesets/cli': 2.29.8(@types/node@20.19.1)


### PR DESCRIPTION
## Summary

Fixes event-catalog/eventcatalog#2745 — AsyncAPI pages rendering as a blank white page in EventCatalog.

### Root cause

Parsed AsyncAPI v3 documents contain **shared (non-circular) object references**: each operation's dereferenced `channel` is the same JS object as the entry under the root `channels` object. The circular-reference-safe serializer introduced in #364 (`safeStringify`, released in 6.1.1) tracked every object it had ever seen, so it treated these shared references as cycles and collapsed them into `$ref: '#'` — a reference to the document root.

With `saveParsedSpecFile: true`, the resulting spec file fails AsyncAPI validation (`asyncapi3-required-operation-channel-unambiguity` plus cascading errors) when EventCatalog re-parses it at build time, so `parsed.document` is undefined and the AsyncAPI page renders completely blank.

### Fix

Track **ancestors** instead of every object seen: shared references are serialized inline, and only true cycles (e.g. the oneOf/allOf discriminator patterns from #364) are replaced with a `$ref`. The YAML path (`yaml.dump`) gets the same cycle-breaking pre-pass so circular schemas can no longer crash it.

### Testing

- New regression test with an AsyncAPI v3 fixture (root `operations` referencing `channels`, external payload schema `$ref`s) that asserts the saved spec file contains no `$ref: "#"` and **re-parses as a valid AsyncAPI document** — fails on the old code, passes with the fix
- Full generator-asyncapi suite: 145/145 passing, including the original #364 circular-ref test
- Verified the reporter's real spec files now round-trip through save → re-parse with zero errors, and render correctly in the EventCatalog AsyncAPI page